### PR TITLE
Bugfix issue 58

### DIFF
--- a/R/getAKData.R
+++ b/R/getAKData.R
@@ -77,8 +77,8 @@ FROM
   # Gjor datoer om til dato-objekt:
   AK %<>%
     mutate_at(
-      vars( ends_with("Dato") ), list( ymd )
-    )
+      vars( ends_with("dato", ignore.case = TRUE) ), list( ymd )
+    ) 
 
 
   # Utledete variabler:

--- a/R/getAKData.R
+++ b/R/getAKData.R
@@ -104,21 +104,22 @@ FROM
       # Uketall:
       ,uke = as.ordered( sprintf(fmt = "%02d", isoweek( ProsedyreDato ) ))
       
-      # Variabel med "yyyy-ukenummer" som tar høyde for uketall spredt over to kalenderår:
+      # Variabel med "yyyy-ukenummer" som tar høyde for uketall spredt over to
+      # kalenderår:
       
       ,aar_uke = ifelse( 
         # hvis uke 01 er i desember...
         test = uke == "01" & maaned_nr == "12"
-        # .. så sier vi at uken tilhører det seneste av de to årene som uke 01 er spredt
-        # over (uke 01 i desember 2019 blir til 2020-01)
+        # .. så sier vi at uken tilhører det seneste av de to årene som uke 01
+        # er spredt over (uke 01 i desember 2019 blir til 2020-01)
         , yes = paste0( as.integer(year(ProsedyreDato)) + 1, "-", uke )
         , no = paste0(aar, "-", uke )
       )
       ,aar_uke = ifelse( 
         # hvis uke 52 eller 53 er i januar...
         test = uke %in% c("52", "53") & maaned_nr == "01"
-        # ...sier vi at hele uken tilhører det tidligste av de to årene som uke 52/53 er
-        # spredt over (1. januar 2017 som er i uke 52 blir til 2016-52)
+        # ...sier vi at hele uken tilhører det tidligste av de to årene som uke
+        # 52/53 er spredt over (1. januar 2017 som er i uke 52 blir til 2016-52)
         , yes = paste0( as.integer(year(ProsedyreDato)) - 1, "-", uke )
         , no = aar_uke
       )

--- a/R/getAKOppfData.R
+++ b/R/getAKOppfData.R
@@ -97,43 +97,6 @@ FROM AortaklaffOppfVar
   #     Sykehusnavn = ifelse( Sykehusnavn == "Akershus universitetssykehus HF" , "Ahus" , Sykehusnavn )
   #   )
   
-  
-  # # Gjøre kategoriske variabler om til factor:
-  # # (ikke fullstendig, må legge til mer etter hvert)
-  # AKOppf %<>%
-  #   mutate(
-  #     ForlopsType1 = as.ordered( ForlopsType1 )
-  #     ,ForlopsType2 = factor( ForlopsType2,
-  #                             levels = c(
-  #                               "Akutt"
-  #                               , "Subakutt"
-  #                               , "Planlagt"
-  #                             ),
-  #                             ordered = TRUE )
-  #     ,Sykehusnavn = as.ordered( Sykehusnavn )
-  #     ,PasientKjonn = factor(PasientKjonn, 
-  #                            levels = c( 
-  #                              "Mann"
-  #                              , "Kvinne"
-  #                              , NA
-  #                            )
-  #                            ,ordered = TRUE
-  #                            ,exclude = NULL # inkluderer NA i levels
-  #     )
-  #     ,VektUkjent = as.ordered( VektUkjent )
-  #     ,NYHA = as.ordered( NYHA )
-  #     ,CanadianClass = as.ordered( CanadianClass )
-  #     ,GangtestIkkeUtfort = as.ordered( GangtestIkkeUtfort )
-  #     ,SKreatininIkkeUtfort = as.ordered( SKreatininIkkeUtfort )
-  #     ,HemoglobinUkjent = as.ordered( HemoglobinUkjent )
-  #     ,VenstreVentrikkelFunksjon = as.ordered( VenstreVentrikkelFunksjon )
-  #     ,Aortainsuffisiens = as.ordered( Aortainsuffisiens )
-  #     ,ParavalvularLekkasje = as.ordered( ParavalvularLekkasje )
-  #     ,Mitralinsuffisiens = as.ordered( Mitralinsuffisiens )
-  #     ,Komplikasjoner = as.ordered( Komplikasjoner )
-  #   )
-  
-  
   # # Utledete variabler:
   # AKOppf %<>%
   #   mutate(

--- a/R/getAnDData.R
+++ b/R/getAnDData.R
@@ -114,7 +114,10 @@ FROM AnnenDiagnostikkVar
         (AvdRESH == 106944) & ( as.Date(ProsedyreDato) >= "2015-01-01" ) # LHLGardermoen
       ) | (
         (AvdRESH == 108141) & ( as.Date(ProsedyreDato) >= "2016-01-01" ) # Ahus
-      ))
+      ) | (
+        (AvdRESH == 4210141) & ( as.Date(ProsedyreDato) >= "2020-02-10" ) # Bodø
+      )
+    )
   
   
   # Gjøre kategoriske variabler om til factor:

--- a/R/getAnDData.R
+++ b/R/getAnDData.R
@@ -87,8 +87,12 @@ FROM AnnenDiagnostikkVar
   AnD %<>%
     mutate(
       Sykehusnavn = ifelse( Sykehusnavn == "Haukeland" , "HUS" , Sykehusnavn ) ,
-      Sykehusnavn = ifelse( Sykehusnavn %in% c("St.Olav", "St. Olav") , "St.Olavs"  , Sykehusnavn ) ,
-      Sykehusnavn = ifelse( Sykehusnavn == "Akershus universitetssykehus HF" , "Ahus" , Sykehusnavn )
+      Sykehusnavn = ifelse( 
+        Sykehusnavn %in% c("St.Olav", "St. Olav") , "St.Olavs"  , Sykehusnavn 
+      ) ,
+      Sykehusnavn = ifelse( 
+        Sykehusnavn == "Akershus universitetssykehus HF" , "Ahus" , Sykehusnavn 
+      )
     )
   
   
@@ -157,6 +161,7 @@ FROM AnnenDiagnostikkVar
                      )
                      ,ordered = TRUE
       )
+      
       ,graft = factor(graft, 
                      levels = c( 
                        "Arterie"
@@ -185,33 +190,42 @@ FROM AnnenDiagnostikkVar
   
   # Utledete variabler:
   AnD %<>% 
-    mutate( 
+    mutate(
       # Div. tidsvariabler:
       #
       # Kalenderår for ProsedyreDato:
-      year = as.ordered( year( ProsedyreDato )),
-      aar = year,
+      aar = as.ordered( year( ProsedyreDato ))
       # Måned:
       # (månedsnr er tosifret; 01, 02, ....)
-      maaned_nr = as.ordered( sprintf(fmt = "%02d", month( ProsedyreDato ) )),
-      maaned = as.ordered( paste0( year, "-", maaned_nr) ),
+      ,maaned_nr = as.ordered( sprintf(fmt = "%02d", month( ProsedyreDato ) ))
+      ,maaned = as.ordered( paste0( aar, "-", maaned_nr) )
       # Kvartal:
-      kvartal = quarter( ProsedyreDato, with_year = TRUE ),
-      # kvartal = as.factor( gsub( "\\.", "-", kvartal) ),
-      kvartal = as.ordered( gsub( "[[:punct:]]", "-Q", kvartal) ),
+      ,kvartal = quarter( ProsedyreDato, with_year = TRUE )
+      # kvartal = as.factor( gsub( "\\.", "-", kvartal) )
+      ,kvartal = as.ordered( gsub( "[[:punct:]]", "-Q", kvartal) )
       # Uketall:
-      uke = as.ordered( sprintf(fmt = "%02d", isoweek( ProsedyreDato ) )),
+      ,uke = as.ordered( sprintf(fmt = "%02d", isoweek( ProsedyreDato ) ))
       
-      # Variabel "yyyy-ukenummer" som tar høyde for uketall som befinner seg i to kalenderår:
-      aar_uke = ifelse( test = uke == "01" & maaned_nr == "12", # hvis uke 01 i desember...
-                        yes = paste0( as.integer(year(ProsedyreDato)) + 1, "-", uke ), # ..sier vi at year er det seneste året som den uken tilhørte
-                        no = paste0(aar, "-", uke )
-      ),
-      aar_uke = ifelse( test = uke %in% c("52", "53") & maaned_nr == "01", # hvis uke 52 eller 53 i januar...
-                        yes = paste0( as.integer(year(ProsedyreDato)) - 1, "-", uke ), # ...sier vi at hele uken tilhører det tidligste året
-                        no = aar_uke
-      ),
-      aar_uke = as.ordered( aar_uke )
+      # Variabel med "yyyy-ukenummer" som tar høyde for uketall spredt over to
+      # kalenderår:
+      
+      ,aar_uke = ifelse( 
+        # hvis uke 01 er i desember...
+        test = uke == "01" & maaned_nr == "12"
+        # .. så sier vi at uken tilhører det seneste av de to årene som uke 01
+        # er spredt over (uke 01 i desember 2019 blir til 2020-01)
+        , yes = paste0( as.integer(year(ProsedyreDato)) + 1, "-", uke )
+        , no = paste0(aar, "-", uke )
+      )
+      ,aar_uke = ifelse( 
+        # hvis uke 52 eller 53 er i januar...
+        test = uke %in% c("52", "53") & maaned_nr == "01"
+        # ...sier vi at hele uken tilhører det tidligste av de to årene som uke
+        # 52/53 er spredt over (1. januar 2017 som er i uke 52 blir til 2016-52)
+        , yes = paste0( as.integer(year(ProsedyreDato)) - 1, "-", uke )
+        , no = aar_uke
+      )
+      ,aar_uke = as.ordered( aar_uke )
     )
   
   

--- a/R/getAnDData.R
+++ b/R/getAnDData.R
@@ -76,11 +76,9 @@ FROM AnnenDiagnostikkVar
   
   # Gjor datoer om til dato-objekt:
   AnD %<>%
-    mutate(
-      ProsedyreDato = ymd( ProsedyreDato ),
-      FodselsDato = ymd( FodselsDato ),
-      HovedDato = ymd( HovedDato )
-    )
+    mutate_at(
+      vars( ends_with("dato", ignore.case = TRUE) ), list( ymd )
+    ) 
   
   
   # Endre Sykehusnavn til kortere versjoner:

--- a/R/getAnDData.R
+++ b/R/getAnDData.R
@@ -121,34 +121,17 @@ FROM AnnenDiagnostikkVar
   
   
   # Gjøre kategoriske variabler om til factor:
-  # (ikke fullstendig, må legge til mer etter hvert)
   AnD %<>%
     mutate(
-      ForlopsType1 = factor( ForlopsType2,
-                             levels = c(
-                               "Angio"
-                               , "Angio+PCI"
-                               , "PCI"
-                             ),
-                             ordered = TRUE )
-      ,ForlopsType2 = factor( ForlopsType2,
+      ForlopsType2 = factor( ForlopsType2,
                              levels = c(
                                "Akutt"
                                , "Subakutt"
                                , "Planlagt"
                              ),
-                             ordered = TRUE )
-      ,Sykehusnavn = as.ordered( Sykehusnavn )
-      ,PasientKjonn = factor(PasientKjonn, 
-                     levels = c( 
-                       "Mann"
-                       , "Kvinne"
-                       , NA
-                     )
-                     ,ordered = TRUE
-                     ,exclude = NULL # inkluderer NA i levels
+                             ordered = TRUE 
       )
-      ,Indikasjon = as.factor( Indikasjon )
+      
       ,segment = factor(segment, 
                      levels = c( 
                        "Proximale RCA (1)",

--- a/R/getFOData.R
+++ b/R/getFOData.R
@@ -88,36 +88,7 @@ FROM ForlopsOversikt
       )
     )
   
-  
-  # Gjøre kategoriske variabler om til factor:
-  FO %<>%
-    mutate(
-      AvdRESH = as.ordered( AvdRESH )
-      ,Sykehusnavn = as.ordered( Sykehusnavn )
-      
-      ,Kommune = addNA( Kommune )
-      ,KommuneNr = addNA( KommuneNr )
-      ,PasientKjonn = factor(PasientKjonn, 
-                             levels = c( 
-                               "Mann"
-                               , "Kvinne"
-                               , NA
-                             )
-                             ,ordered = TRUE
-                             ,exclude = NULL # inkluderer NA i levels
-      )
-      , erMann = addNA( erMann )
-      , Norsktalende = addNA( Norsktalende)
-      , Avdod = addNA( Avdod)
-      , BasisRegStatus = addNA( BasisRegStatus )
-      
-      ,ForlopsType1 = as.ordered( ForlopsType1 )
-      ,ForlopsType1Num = as.ordered( ForlopsType1Num )
-      ,ForlopsType2Num = as.ordered( ForlopsType2Num )
-      ,ErOppflg = as.ordered( ErOppflg )
-    )
-  
-  
+
   # Utledete variabler:
   FO %<>% 
     mutate( 

--- a/R/getFOData.R
+++ b/R/getFOData.R
@@ -83,7 +83,10 @@ FROM ForlopsOversikt
         (AvdRESH == 106944) & ( as.Date(HovedDato) >= "2015-01-01" ) # LHLGardermoen
       ) | (
         (AvdRESH == 108141) & ( as.Date(HovedDato) >= "2016-01-01" ) # Ahus
-      ))
+      ) | (
+        (AvdRESH == 4210141) & ( as.Date(HovedDato) >= "2020-02-10" ) # Bodø
+      )
+    )
   
   
   # Gjøre kategoriske variabler om til factor:

--- a/R/getFOData.R
+++ b/R/getFOData.R
@@ -44,11 +44,9 @@ FROM ForlopsOversikt
   
   # Gjor datoer om til dato-objekt:
   FO %<>%
-    mutate(
-      AvdodDato = ymd( AvdodDato )
-      ,FodselsDato = ymd( FodselsDato )
-      ,HovedDato = ymd( HovedDato )
-    )
+    mutate_at(
+      vars( ends_with("dato", ignore.case = TRUE) ), list( ymd )
+    ) 
   
   
   # Endre Sykehusnavn til kortere versjoner:

--- a/R/getFOData.R
+++ b/R/getFOData.R
@@ -55,13 +55,18 @@ FROM ForlopsOversikt
   FO %<>%
     mutate(
       Sykehusnavn = ifelse( Sykehusnavn == "Haukeland" , "HUS" , Sykehusnavn ) ,
-      Sykehusnavn = ifelse( Sykehusnavn %in% c("St.Olav", "St. Olav") , "St.Olavs"  , Sykehusnavn ) ,
-      Sykehusnavn = ifelse( Sykehusnavn == "Akershus universitetssykehus HF" , "Ahus" , Sykehusnavn )
+      Sykehusnavn = ifelse( 
+        Sykehusnavn %in% c("St.Olav", "St. Olav") , "St.Olavs"  , Sykehusnavn 
+      ) ,
+      Sykehusnavn = ifelse( 
+        Sykehusnavn == "Akershus universitetssykehus HF" , "Ahus" , Sykehusnavn 
+      )
     )
   
   # Tar bort forløp fra før sykehusene ble offisielt med i NORIC (potensielle
   # "tøyseregistreringer")
-  # ForlopsOversikt inneholder ikke ProsedyreDato -> bruker derfor HovedDato til å filtrere
+  # ForlopsOversikt inneholder ikke ProsedyreDato. Derfor brukes HovedDato til å
+  # filtrere.
   
   FO %<>%
     filter(
@@ -91,33 +96,42 @@ FROM ForlopsOversikt
 
   # Utledete variabler:
   FO %<>% 
-    mutate( 
+    mutate(
       # Div. tidsvariabler:
       #
       # Kalenderår for HovedDato:
-      year = as.ordered( year( HovedDato )),
-      aar = year,
+      aar = as.ordered( year( HovedDato ))
       # Måned:
       # (månedsnr er tosifret; 01, 02, ....)
-      maaned_nr = as.ordered( sprintf(fmt = "%02d", month( HovedDato ) )),
-      maaned = as.ordered( paste0( year, "-", maaned_nr) ),
+      ,maaned_nr = as.ordered( sprintf(fmt = "%02d", month( HovedDato ) ))
+      ,maaned = as.ordered( paste0( aar, "-", maaned_nr) )
       # Kvartal:
-      kvartal = quarter( HovedDato, with_year = TRUE ),
-      # kvartal = as.factor( gsub( "\\.", "-", kvartal) ),
-      kvartal = as.ordered( gsub( "[[:punct:]]", "-Q", kvartal) ),
+      ,kvartal = quarter( HovedDato, with_year = TRUE )
+      # kvartal = as.factor( gsub( "\\.", "-", kvartal) )
+      ,kvartal = as.ordered( gsub( "[[:punct:]]", "-Q", kvartal) )
       # Uketall:
-      uke = as.ordered( sprintf(fmt = "%02d", isoweek( HovedDato ) )),
+      ,uke = as.ordered( sprintf(fmt = "%02d", isoweek( HovedDato ) ))
       
-      # Variabel "yyyy-ukenummer" som tar høyde for uketall som befinner seg i to kalenderår:
-      aar_uke = ifelse( test = uke == "01" & maaned_nr == "12", # hvis uke 01 i desember...
-                        yes = paste0( as.integer(year(HovedDato)) + 1, "-", uke ), # ..sier vi at year er det seneste året som den uken tilhørte
-                        no = paste0(aar, "-", uke )
-      ),
-      aar_uke = ifelse( test = uke %in% c("52", "53") & maaned_nr == "01", # hvis uke 52 eller 53 i januar...
-                        yes = paste0( as.integer(year(HovedDato)) - 1, "-", uke ), # ...sier vi at hele uken tilhører det tidligste året
-                        no = aar_uke
-      ),
-      aar_uke = as.ordered( aar_uke )
+      # Variabel med "yyyy-ukenummer" som tar høyde for uketall spredt over to
+      # kalenderår:
+      
+      ,aar_uke = ifelse( 
+        # hvis uke 01 er i desember...
+        test = uke == "01" & maaned_nr == "12"
+        # .. så sier vi at uken tilhører det seneste av de to årene som uke 01
+        # er spredt over (uke 01 i desember 2019 blir til 2020-01)
+        , yes = paste0( as.integer(year(HovedDato)) + 1, "-", uke )
+        , no = paste0(aar, "-", uke )
+      )
+      ,aar_uke = ifelse( 
+        # hvis uke 52 eller 53 er i januar...
+        test = uke %in% c("52", "53") & maaned_nr == "01"
+        # ...sier vi at hele uken tilhører det tidligste av de to årene som uke
+        # 52/53 er spredt over (1. januar 2017 som er i uke 52 blir til 2016-52)
+        , yes = paste0( as.integer(year(HovedDato)) - 1, "-", uke )
+        , no = aar_uke
+      )
+      ,aar_uke = as.ordered( aar_uke )
     )
   
   

--- a/R/getLocalAPData.R
+++ b/R/getLocalAPData.R
@@ -74,22 +74,6 @@ FROM AngioPCIVar
   
   
   
-  # Klokkeslett med "01.01.70 " som prefix fikses:
-  AP %<>%
-    mutate(
-      ProsedyreTid = gsub( "01.01.70 " , "" , ProsedyreTid ) ,
-      SymptomTid = gsub( "01.01.70 " , "" , SymptomTid ) ,
-      BesUtlEKGTid = gsub( "01.01.70 " , "" , BesUtlEKGTid ) ,
-      AnkomstPCITid = gsub( "01.01.70 " , "" , AnkomstPCITid ) ,
-      ApningKarTid = gsub( "01.01.70 " , "" , ApningKarTid ) ,
-      InnleggelseHenvisendeSykehusTid = 
-        gsub( "01.01.70 " , "" , InnleggelseHenvisendeSykehusTid ) ,
-      SymptomdebutTid = gsub( "01.01.70 " , "" , SymptomdebutTid ) ,
-      BeslEKGTid = gsub( "01.01.70 " , "" , BeslEKGTid ) ,
-      TrombolyseTid = gsub( "01.01.70 " , "" , TrombolyseTid )
-      )
-  
-  
   # Gjor datoer om til dato-objekt:
   AP %<>%
     mutate(

--- a/R/getLocalAPData.R
+++ b/R/getLocalAPData.R
@@ -76,24 +76,9 @@ FROM AngioPCIVar
   
   # Gjor datoer om til dato-objekt:
   AP %<>%
-    mutate(
-      AnkomstPCIDato = ymd( AnkomstPCIDato )
-      ,ApningKarDato = ymd( ApningKarDato )
-      ,AvdodDato = ymd( AvdodDato )
-      ,BeslEKGDato = ymd( BeslEKGDato )
-      ,BesUtlEKGDato = ymd( BesUtlEKGDato )
-      ,FodselsDato = ymd( FodselsDato )
-      ,HovedDato = ymd( HovedDato )
-      ,InnleggelseHenvisendeSykehusDato = 
-        ymd( InnleggelseHenvisendeSykehusDato )
-      ,PasientRegDato = ymd( PasientRegDato )
-      ,ProsedyreDato = ymd( ProsedyreDato )
-      ,SymptomDato = ymd( SymptomDato )
-      ,SymptomdebutDato = ymd( SymptomdebutDato )
-      ,TrombolyseDato = ymd( TrombolyseDato )
-      ,UtskrevetDodsdato = ymd( UtskrevetDodsdato )
-      ,Utskrivningsdato = ymd( Utskrivningsdato )
-    )
+    mutate_at(
+      vars( ends_with("dato", ignore.case = TRUE) ), list( ymd )
+    ) 
   
   
   # Endre Sykehusnavn til kortere versjoner:

--- a/R/getLocalAPData.R
+++ b/R/getLocalAPData.R
@@ -57,7 +57,7 @@ FROM AngioPCIVar
       ,KommuneNr
       ,Fylke
       ,Fylkenr
-      # ,PasientKjonn # Finnes per dags dato i AP (heter ikke PasientKjonn, men Kjonn)
+      # ,PasientKjonn # Finnes per dags dato i AP (men heter Kjonn)
       ,PasientAlder
       ,ForlopsType1
       ,ForlopsType2
@@ -82,7 +82,8 @@ FROM AngioPCIVar
       BesUtlEKGTid = gsub( "01.01.70 " , "" , BesUtlEKGTid ) ,
       AnkomstPCITid = gsub( "01.01.70 " , "" , AnkomstPCITid ) ,
       ApningKarTid = gsub( "01.01.70 " , "" , ApningKarTid ) ,
-      InnleggelseHenvisendeSykehusTid = gsub( "01.01.70 " , "" , InnleggelseHenvisendeSykehusTid ) ,
+      InnleggelseHenvisendeSykehusTid = 
+        gsub( "01.01.70 " , "" , InnleggelseHenvisendeSykehusTid ) ,
       SymptomdebutTid = gsub( "01.01.70 " , "" , SymptomdebutTid ) ,
       BeslEKGTid = gsub( "01.01.70 " , "" , BeslEKGTid ) ,
       TrombolyseTid = gsub( "01.01.70 " , "" , TrombolyseTid )
@@ -99,7 +100,8 @@ FROM AngioPCIVar
       ,BesUtlEKGDato = ymd( BesUtlEKGDato )
       ,FodselsDato = ymd( FodselsDato )
       ,HovedDato = ymd( HovedDato )
-      ,InnleggelseHenvisendeSykehusDato = ymd( InnleggelseHenvisendeSykehusDato )
+      ,InnleggelseHenvisendeSykehusDato = 
+        ymd( InnleggelseHenvisendeSykehusDato )
       ,PasientRegDato = ymd( PasientRegDato )
       ,ProsedyreDato = ymd( ProsedyreDato )
       ,SymptomDato = ymd( SymptomDato )
@@ -114,8 +116,12 @@ FROM AngioPCIVar
   AP %<>%
     mutate(
       Sykehusnavn = ifelse( Sykehusnavn == "Haukeland" , "HUS" , Sykehusnavn ) ,
-      Sykehusnavn = ifelse( Sykehusnavn %in% c("St.Olav", "St. Olav") , "St.Olavs"  , Sykehusnavn ) ,
-      Sykehusnavn = ifelse( Sykehusnavn == "Akershus universitetssykehus HF" , "Ahus" , Sykehusnavn )
+      Sykehusnavn = ifelse( 
+        Sykehusnavn %in% c("St.Olav", "St. Olav") , "St.Olavs"  , Sykehusnavn 
+      ) ,
+      Sykehusnavn = ifelse( 
+        Sykehusnavn == "Akershus universitetssykehus HF" , "Ahus" , Sykehusnavn 
+      )
     )
   
   # Tar bort forløp fra før sykehusene ble offisielt med i NORIC (potensielle
@@ -162,33 +168,42 @@ FROM AngioPCIVar
   
   # Utledete variabler:
   AP %<>% 
-    mutate( 
+    mutate(
       # Div. tidsvariabler:
       #
       # Kalenderår for ProsedyreDato:
-      year = as.ordered( year( ProsedyreDato )),
-      aar = year,
+      aar = as.ordered( year( ProsedyreDato ))
       # Måned:
       # (månedsnr er tosifret; 01, 02, ....)
-      maaned_nr = as.ordered( sprintf(fmt = "%02d", month( ProsedyreDato ) )),
-      maaned = as.ordered( paste0( year, "-", maaned_nr) ),
+      ,maaned_nr = as.ordered( sprintf(fmt = "%02d", month( ProsedyreDato ) ))
+      ,maaned = as.ordered( paste0( aar, "-", maaned_nr) )
       # Kvartal:
-      kvartal = quarter( ProsedyreDato, with_year = TRUE ),
-      # kvartal = as.factor( gsub( "\\.", "-", kvartal) ),
-      kvartal = as.ordered( gsub( "[[:punct:]]", "-Q", kvartal) ),
+      ,kvartal = quarter( ProsedyreDato, with_year = TRUE )
+      # kvartal = as.factor( gsub( "\\.", "-", kvartal) )
+      ,kvartal = as.ordered( gsub( "[[:punct:]]", "-Q", kvartal) )
       # Uketall:
-      uke = as.ordered( sprintf(fmt = "%02d", isoweek( ProsedyreDato ) )),
-
-      # Variabel "yyyy-ukenummer" som tar høyde for uketall som befinner seg i to kalenderår:
-      aar_uke = ifelse( test = uke == "01" & maaned_nr == "12", # hvis uke 01 i desember...
-                        yes = paste0( as.integer(year(ProsedyreDato)) + 1, "-", uke ), # ..sier vi at year er det seneste året som den uken tilhørte
-                        no = paste0(aar, "-", uke )
-      ),
-      aar_uke = ifelse( test = uke %in% c("52", "53") & maaned_nr == "01", # hvis uke 52 eller 53 i januar...
-                        yes = paste0( as.integer(year(ProsedyreDato)) - 1, "-", uke ), # ...sier vi at hele uken tilhører det tidligste året
-                        no = aar_uke
-      ),
-      aar_uke = as.ordered( aar_uke )
+      ,uke = as.ordered( sprintf(fmt = "%02d", isoweek( ProsedyreDato ) ))
+      
+      # Variabel med "yyyy-ukenummer" som tar høyde for uketall spredt over to
+      # kalenderår:
+      
+      ,aar_uke = ifelse( 
+        # hvis uke 01 er i desember...
+        test = uke == "01" & maaned_nr == "12"
+        # .. så sier vi at uken tilhører det seneste av de to årene som uke 01
+        # er spredt over (uke 01 i desember 2019 blir til 2020-01)
+        , yes = paste0( as.integer(year(ProsedyreDato)) + 1, "-", uke )
+        , no = paste0(aar, "-", uke )
+      )
+      ,aar_uke = ifelse( 
+        # hvis uke 52 eller 53 er i januar...
+        test = uke %in% c("52", "53") & maaned_nr == "01"
+        # ...sier vi at hele uken tilhører det tidligste av de to årene som uke
+        # 52/53 er spredt over (1. januar 2017 som er i uke 52 blir til 2016-52)
+        , yes = paste0( as.integer(year(ProsedyreDato)) - 1, "-", uke )
+        , no = aar_uke
+      )
+      ,aar_uke = as.ordered( aar_uke )
     )
   
 

--- a/R/getLocalAPData.R
+++ b/R/getLocalAPData.R
@@ -140,7 +140,10 @@ FROM AngioPCIVar
         (AvdRESH == 106944) & ( as.Date(ProsedyreDato) >= "2015-01-01" ) # LHLGardermoen
       ) | (
         (AvdRESH == 108141) & ( as.Date(ProsedyreDato) >= "2016-01-01" ) # Ahus
-      ))
+      ) | (
+        (AvdRESH == 4210141) & ( as.Date(ProsedyreDato) >= "2020-02-10" ) # Bodø
+      )
+    )
   
   
   # Gjøre kategoriske variabler om til factor:

--- a/R/getLocalAPData.R
+++ b/R/getLocalAPData.R
@@ -156,27 +156,7 @@ FROM AngioPCIVar
                                , "Subakutt"
                                , "Planlagt"
                              ),
-                             ordered = TRUE ),
-      Indikasjon = as.factor( Indikasjon ),
-      Kjonn = factor(Kjonn, 
-                     levels = c( 
-                       "Mann"
-                       , "Kvinne"
-                       , NA
-                       )
-                     ,ordered = TRUE
-                     ,exclude = NULL # inkluderer NA i levels
-                     ),
-      OverflyttetFra = as.factor( OverflyttetFra ),
-      ProsedyreType = factor( ProsedyreType,
-                              levels = c(
-                                "Angio"
-                                ,"Angio + PCI"
-                                ,"PCI"
-                              ),
-                              ordered = TRUE ),
-      Sykehusnavn = as.ordered( Sykehusnavn )
-      
+                             ordered = TRUE )
     )
   
   

--- a/R/getLocalAnPData.R
+++ b/R/getLocalAnPData.R
@@ -113,7 +113,10 @@ FROM AndreProsedyrerVar
         (AvdRESH == 106944) & ( as.Date(ProsedyreDato) >= "2015-01-01" ) # LHLGardermoen
       ) | (
         (AvdRESH == 108141) & ( as.Date(ProsedyreDato) >= "2016-01-01" ) # Ahus
-      ))
+      ) | (
+        (AvdRESH == 4210141) & ( as.Date(ProsedyreDato) >= "2020-02-10" ) # Bodø
+      )
+    )
   
   
   

--- a/R/getLocalAnPData.R
+++ b/R/getLocalAnPData.R
@@ -69,12 +69,6 @@ FROM AndreProsedyrerVar
                   suffix = c("", ".FO"))
   
 
-  # Klokkeslett med "01.01.70 " som prefix fikses:
-  AnP %<>%
-    mutate(
-      ProsedyreTid = gsub( "01.01.70 " , "" , ProsedyreTid )
-    )
-  
   # Gjor datoer om til dato-objekt:
   AnP %<>%
     mutate_at(

--- a/R/getLocalAnPData.R
+++ b/R/getLocalAnPData.R
@@ -77,13 +77,11 @@ FROM AndreProsedyrerVar
   
   # Gjor datoer om til dato-objekt:
   AnP %<>%
-    mutate(
-      FodselsDato = ymd( FodselsDato )
-      ,HovedDato = ymd( HovedDato )
-      ,ProsedyreDato = ymd( ProsedyreDato )
-    )
+    mutate_at(
+      vars( ends_with("Dato") ), list( ymd )
+    ) 
   
-  
+ 
   # Endre Sykehusnavn til kortere versjoner:
   AnP %<>%
     mutate(
@@ -123,34 +121,13 @@ FROM AndreProsedyrerVar
   # (ikke fullstendig, må legget til mer etter hvert)
   AnP %<>%
     mutate(
-      AnnenProsType = factor( AnnenProsType,
-                                levels = c(
-                                  "Aortaballongpumpe"           
-                                  ,"ECMO"                        
-                                  ,"Høyre hjertekateterisering"  
-                                  ,"Impella"                    
-                                  ,"Lukking av ASD/PFO"          
-                                  ,"Lukking av venstre aurikkel" 
-                                  ,"Perikardiocentese"           
-                                  ,"PTSMA"                      
-                                  ,"Temporær pacemaker"          
-                                  ,"Ventilfilming"
-                                  # ,"Ikke registrert" 
-                                ),
-                                ordered = TRUE
-      ),
-      ForlopsType1 = as.factor( ForlopsType1 ),
-      # (Hastegrad finnes ikke i AndreProsedyrerVar)
       ForlopsType2 = factor( ForlopsType2,
                              levels = c(
                                "Akutt"
                                , "Subakutt"
                                , "Planlagt"
                              ),
-                             ordered = TRUE ),
-      PasientKjonn = factor(PasientKjonn, levels = c( "Mann", "Kvinne"), ordered = TRUE),
-      Sykehusnavn = as.ordered( Sykehusnavn )
-      
+                             ordered = TRUE )
     )
   
   

--- a/R/getLocalAnPData.R
+++ b/R/getLocalAnPData.R
@@ -72,7 +72,7 @@ FROM AndreProsedyrerVar
   # Gjor datoer om til dato-objekt:
   AnP %<>%
     mutate_at(
-      vars( ends_with("Dato") ), list( ymd )
+      vars( ends_with("dato", ignore.case = TRUE) ), list( ymd )
     ) 
   
  

--- a/R/getLocalCTData.R
+++ b/R/getLocalCTData.R
@@ -108,7 +108,10 @@ FROM CTAngioVar
         (AvdRESH == 106944) & ( as.Date(UndersokDato) >= "2015-01-01" ) # LHLGardermoen
       ) | (
         (AvdRESH == 108141) & ( as.Date(UndersokDato) >= "2016-01-01" ) # Ahus
-      ))
+      ) | (
+        (AvdRESH == 4210141) & ( as.Date(UndersokDato) >= "2020-02-10" ) # Bodø
+      )
+    )
   
   
   # Utledete variabler:

--- a/R/getLocalCTData.R
+++ b/R/getLocalCTData.R
@@ -70,11 +70,12 @@ FROM CTAngioVar
                                   ),
                    suffix = c("", ".FO"))
   
+  
   # Gjor datoer om til dato-objekt:
   CT %<>%
     mutate_at(
-      vars( ends_with("Dato", ignore.case = FALSE) ), list( ymd )
-    )
+      vars( ends_with("dato", ignore.case = TRUE) ), list( ymd )
+    ) 
   
   
   # Endre Sykehusnavn til kortere versjoner:

--- a/R/getLocalCTData.R
+++ b/R/getLocalCTData.R
@@ -81,8 +81,12 @@ FROM CTAngioVar
   CT %<>%
     mutate(
       Sykehusnavn = ifelse( Sykehusnavn == "Haukeland" , "HUS" , Sykehusnavn ) ,
-      Sykehusnavn = ifelse( Sykehusnavn %in% c("St.Olav", "St. Olav") , "St.Olavs"  , Sykehusnavn ) ,
-      Sykehusnavn = ifelse( Sykehusnavn == "Akershus universitetssykehus HF" , "Ahus" , Sykehusnavn )
+      Sykehusnavn = ifelse( 
+        Sykehusnavn %in% c("St.Olav", "St. Olav") , "St.Olavs"  , Sykehusnavn 
+      ) ,
+      Sykehusnavn = ifelse( 
+        Sykehusnavn == "Akershus universitetssykehus HF" , "Ahus" , Sykehusnavn 
+      )
     )
   
   
@@ -132,21 +136,22 @@ FROM CTAngioVar
       # Uketall:
       ,uke = as.ordered( sprintf(fmt = "%02d", isoweek( UndersokDato ) ))
       
-      # Variabel med "yyyy-ukenummer" som tar høyde for uketall spredt over to kalenderår:
+      # Variabel med "yyyy-ukenummer" som tar høyde for uketall spredt over to
+      # kalenderår:
       
       ,aar_uke = ifelse( 
         # hvis uke 01 er i desember...
         test = uke == "01" & maaned_nr == "12"
-        # .. så sier vi at uken tilhører det seneste av de to årene som uke 01 er spredt
-        # over (uke 01 i desember 2019 blir til 2020-01)
+        # .. så sier vi at uken tilhører det seneste av de to årene som uke 01
+        # er spredt over (uke 01 i desember 2019 blir til 2020-01)
         , yes = paste0( as.integer(year(UndersokDato)) + 1, "-", uke )
         , no = paste0(aar, "-", uke )
       )
       ,aar_uke = ifelse( 
         # hvis uke 52 eller 53 er i januar...
         test = uke %in% c("52", "53") & maaned_nr == "01"
-        # ...sier vi at hele uken tilhører det tidligste av de to årene som uke 52/53 er
-        # spredt over (1. januar 2017 som er i uke 52 blir til 2016-52)
+        # ...sier vi at hele uken tilhører det tidligste av de to årene som uke
+        # 52/53 er spredt over (1. januar 2017 som er i uke 52 blir til 2016-52)
         , yes = paste0( as.integer(year(UndersokDato)) - 1, "-", uke )
         , no = aar_uke
       )

--- a/R/getLocalSOData.R
+++ b/R/getLocalSOData.R
@@ -51,8 +51,12 @@ getLocalSOData <- function(registryName, singleRow = FALSE, ...) {
   SO %<>%
     mutate(
       Sykehusnavn = ifelse( Sykehusnavn == "Haukeland" , "HUS" , Sykehusnavn ) ,
-      Sykehusnavn = ifelse( Sykehusnavn %in% c("St.Olav", "St. Olav") , "St.Olavs"  , Sykehusnavn ) ,
-      Sykehusnavn = ifelse( Sykehusnavn == "Akershus universitetssykehus HF" , "Ahus" , Sykehusnavn )
+      Sykehusnavn = ifelse( 
+        Sykehusnavn %in% c("St.Olav", "St. Olav") , "St.Olavs"  , Sykehusnavn 
+      ) ,
+      Sykehusnavn = ifelse( 
+        Sykehusnavn == "Akershus universitetssykehus HF" , "Ahus" , Sykehusnavn 
+      )
     )
   
   
@@ -96,30 +100,39 @@ getLocalSOData <- function(registryName, singleRow = FALSE, ...) {
                                 ),
       # Div. tidsvariabler:
       #
-      # Kalenderår for ProsedyreDato:
-      year = as.ordered( year( HovedDato )),
-      aar = year,
+      # Kalenderår for HovedDato:
+      aar = as.ordered( year( HovedDato ))
       # Måned:
       # (månedsnr er tosifret; 01, 02, ....)
-      maaned_nr = as.ordered( sprintf(fmt = "%02d", month( HovedDato ) )),
-      maaned = as.ordered( paste0( year, "-", maaned_nr) ),
+      ,maaned_nr = as.ordered( sprintf(fmt = "%02d", month( HovedDato ) ))
+      ,maaned = as.ordered( paste0( aar, "-", maaned_nr) )
       # Kvartal:
-      kvartal = quarter( HovedDato, with_year = TRUE ),
-      # kvartal = as.factor( gsub( "\\.", "-", kvartal) ),
-      kvartal = as.ordered( gsub( "[[:punct:]]", "-Q", kvartal) ),
+      ,kvartal = quarter( HovedDato, with_year = TRUE )
+      # kvartal = as.factor( gsub( "\\.", "-", kvartal) )
+      ,kvartal = as.ordered( gsub( "[[:punct:]]", "-Q", kvartal) )
       # Uketall:
-      uke = as.ordered( sprintf(fmt = "%02d", isoweek( HovedDato ) )),
+      ,uke = as.ordered( sprintf(fmt = "%02d", isoweek( HovedDato ) ))
       
-      # Variabel "yyyy-ukenummer" som tar høyde for uketall som befinner seg i to kalenderår:
-      aar_uke = ifelse( test = uke == "01" & maaned_nr == "12", # hvis uke 01 i desember...
-                        yes = paste0( as.integer(year(HovedDato)) + 1, "-", uke ), # ..sier vi at year er det seneste året som den uken tilhørte
-                        no = paste0(aar, "-", uke )
-      ),
-      aar_uke = ifelse( test = uke %in% c("52", "53") & maaned_nr == "01", # hvis uke 52 eller 53 i januar...
-                        yes = paste0( as.integer(year(HovedDato)) - 1, "-", uke ), # ...sier vi at hele uken tilhører det tidligste året
-                        no = aar_uke
-      ),
-      aar_uke = as.ordered( aar_uke )
+      # Variabel med "yyyy-ukenummer" som tar høyde for uketall spredt over to
+      # kalenderår:
+      
+      ,aar_uke = ifelse( 
+        # hvis uke 01 er i desember...
+        test = uke == "01" & maaned_nr == "12"
+        # .. så sier vi at uken tilhører det seneste av de to årene som uke 01
+        # er spredt over (uke 01 i desember 2019 blir til 2020-01)
+        , yes = paste0( as.integer(year(HovedDato)) + 1, "-", uke )
+        , no = paste0(aar, "-", uke )
+      )
+      ,aar_uke = ifelse( 
+        # hvis uke 52 eller 53 er i januar...
+        test = uke %in% c("52", "53") & maaned_nr == "01"
+        # ...sier vi at hele uken tilhører det tidligste av de to årene som uke
+        # 52/53 er spredt over (1. januar 2017 som er i uke 52 blir til 2016-52)
+        , yes = paste0( as.integer(year(HovedDato)) - 1, "-", uke )
+        , no = aar_uke
+      )
+      ,aar_uke = as.ordered( aar_uke )
     ) 
   
   SO

--- a/R/getLocalSOData.R
+++ b/R/getLocalSOData.R
@@ -78,7 +78,10 @@ getLocalSOData <- function(registryName, singleRow = FALSE, ...) {
         (AvdRESH == 106944) & ( as.Date(HovedDato) >= "2015-01-01" ) # LHLGardermoen
       ) | (
         (AvdRESH == 108141) & ( as.Date(HovedDato) >= "2016-01-01" ) # Ahus
-      ))
+      ) | (
+        (AvdRESH == 4210141) & ( as.Date(HovedDato) >= "2020-02-10" ) # Bodø
+      )
+    )
   
   
   # Gjøre kategoriske variabler om til factor:

--- a/R/getLocalSOData.R
+++ b/R/getLocalSOData.R
@@ -83,13 +83,7 @@ getLocalSOData <- function(registryName, singleRow = FALSE, ...) {
       )
     )
   
-  
-  # Gjøre kategoriske variabler om til factor:
-  SO %<>%
-    mutate(
-      Skjemanavn = as.ordered( Skjemanavn ),
-      Sykehusnavn = as.ordered( Sykehusnavn )
-    )
+
   
   
   # Utledete variabler:

--- a/R/getLocalSOData.R
+++ b/R/getLocalSOData.R
@@ -41,8 +41,8 @@ getLocalSOData <- function(registryName, singleRow = FALSE, ...) {
   # Gjor datoer om til dato-objekt:
   SO %<>%
     mutate(
-      OpprettetDato = ymd( OpprettetDato )
-      ,SistLagretDato = ymd( SistLagretDato )
+      OpprettetDato = ymd_hms( OpprettetDato )
+      ,SistLagretDato = ymd_hms( SistLagretDato )
       ,HovedDato = ymd( HovedDato )
     )
   

--- a/R/getLocalSSData.R
+++ b/R/getLocalSSData.R
@@ -119,19 +119,6 @@ FROM
   # (ikke fullstendig, må legge til mer etter hvert)
   SS %<>%
     mutate(
-      Etterdilatasjon = factor( Etterdilatasjon,
-                          levels = c(
-                            "Ja"
-                            , "Ja, gjennom stentmaskene"
-                            , "Ja, Kissing-Balloon teknikk"
-                            , "Ja, separate ballonger gjennom stentmaskene og i stent"
-                            , "Nei"
-                            , "Ukjent"
-                            , NA)
-                          ,exclude = NULL # inkluderer NA i levels
-                          ,ordered = TRUE
-      ),
-      Indikasjon = as.factor( Indikasjon ),
       Graft = factor( Graft,
                       levels = c(
                         "Nei"
@@ -140,43 +127,9 @@ FROM
                       )
                       ,exclude = NULL # inkluderer NA i levels
                       ,ordered = TRUE 
-      ),
-      LokalSuksess = factor( LokalSuksess,
-                             levels = c(
-                               "Ja"
-                               ,"Nei"
-                               ,NA
-                             )
-                             ,exclude = NULL # inkluderer NA i levels
-                             ,ordered = TRUE 
-      ),
-      PasientKjonn = factor(PasientKjonn, 
-                            levels = c( 
-                              "Mann"
-                              , "Kvinne"
-                              , NA
-                            )
-                            ,exclude = NULL # inkluderer NA i levels
-                            ,ordered = TRUE
-      ),
-      ProsedyreType = factor( ProsedyreType,
-                              levels = c(
-                                "Annen terapi"
-                                ,"Atherectomi"
-                                ,"Ballong + Stent"
-                                ,"Ballongdilatasjon"
-                                ,"Cutting Ballon"
-                                ,"Diagnostikk"
-                                ,"Direktestent"
-                                ,"Medikamentell ballong"
-                                ,"Medikamentell ballong + Stent"
-                                ,"Rotablator"
-                                ,"Wireforsøk"
-                              ),
-                              ordered = TRUE 
-                              ),
-      Segment = as.ordered( Segment ),
-      Stenoseklasse = factor( Stenoseklasse,
+      )
+      
+      ,Stenoseklasse = factor( Stenoseklasse,
                               levels = c(
                                 "A"
                                 ,"B1"
@@ -188,8 +141,9 @@ FROM
                                 ,"Annet"
                               ),
                               ordered = TRUE 
-                              ),
-      StenoseType = factor( StenoseType,
+                              )
+      
+      ,StenoseType = factor( StenoseType,
                               levels = c(
                                 "DeNovo"
                                 ,"In-stent restenose"
@@ -197,8 +151,8 @@ FROM
                                 ,"Andre restenoser"
                               ),
                               ordered = TRUE 
-                              ),
-      StentType = factor( StentType,
+                              )
+      ,StentType = factor( StentType,
                           levels = c(
                             "DES"
                             , "BMS"
@@ -206,8 +160,7 @@ FROM
                             , NA)
                           ,exclude = NULL # inkluderer NA i levels
                           ,ordered = TRUE
-      ),
-      Sykehusnavn = as.ordered( Sykehusnavn )
+      )
       
     )
   

--- a/R/getLocalSSData.R
+++ b/R/getLocalSSData.R
@@ -83,8 +83,12 @@ FROM
   SS %<>%
     mutate(
       Sykehusnavn = ifelse( Sykehusnavn == "Haukeland" , "HUS" , Sykehusnavn ) ,
-      Sykehusnavn = ifelse( Sykehusnavn %in% c("St.Olav", "St. Olav") , "St.Olavs"  , Sykehusnavn ) ,
-      Sykehusnavn = ifelse( Sykehusnavn == "Akershus universitetssykehus HF" , "Ahus" , Sykehusnavn )
+      Sykehusnavn = ifelse( 
+        Sykehusnavn %in% c("St.Olav", "St. Olav") , "St.Olavs"  , Sykehusnavn 
+      ) ,
+      Sykehusnavn = ifelse( 
+        Sykehusnavn == "Akershus universitetssykehus HF" , "Ahus" , Sykehusnavn 
+      )
     )
   
   # Tar bort forløp fra før sykehusene ble offisielt med i NORIC (potensielle
@@ -171,40 +175,51 @@ FROM
       # Div. tidsvariabler:
       #
       # Kalenderår for ProsedyreDato:
-      year = as.ordered( year( ProsedyreDato )),
-      aar = year,
+      aar = as.ordered( year( ProsedyreDato ))
       # Måned:
       # (månedsnr er tosifret; 01, 02, ....)
-      maaned_nr = as.ordered( sprintf(fmt = "%02d", month( ProsedyreDato ) )),
-      maaned = as.ordered( paste0( year, "-", maaned_nr) ),
+      ,maaned_nr = as.ordered( sprintf(fmt = "%02d", month( ProsedyreDato ) ))
+      ,maaned = as.ordered( paste0( aar, "-", maaned_nr) )
       # Kvartal:
-      kvartal = quarter( ProsedyreDato, with_year = TRUE ),
-      # kvartal = as.factor( gsub( "\\.", "-", kvartal) ),
-      kvartal = as.ordered( gsub( "[[:punct:]]", "-Q", kvartal) ),
+      ,kvartal = quarter( ProsedyreDato, with_year = TRUE )
+      # kvartal = as.factor( gsub( "\\.", "-", kvartal) )
+      ,kvartal = as.ordered( gsub( "[[:punct:]]", "-Q", kvartal) )
       # Uketall:
-      uke = as.ordered( sprintf(fmt = "%02d", isoweek( ProsedyreDato ) )),
+      ,uke = as.ordered( sprintf(fmt = "%02d", isoweek( ProsedyreDato ) ))
       
-      # Variabel "yyyy-ukenummer" som tar høyde for uketall som befinner seg i to kalenderår:
-      aar_uke = ifelse( test = uke == "01" & maaned_nr == "12", # hvis uke 01 i desember...
-                        yes = paste0( as.integer(year(ProsedyreDato)) + 1, "-", uke ), # ..sier vi at year er det seneste året som den uken tilhørte
-                        no = paste0(aar, "-", uke )
-      ),
-      aar_uke = ifelse( test = uke %in% c("52", "53") & maaned_nr == "01", # hvis uke 52 eller 53 i januar...
-                        yes = paste0( as.integer(year(ProsedyreDato)) - 1, "-", uke ), # ...sier vi at hele uken tilhører det tidligste året
-                        no = aar_uke
-      ),
-      aar_uke = as.ordered( aar_uke )
+      # Variabel med "yyyy-ukenummer" som tar høyde for uketall spredt over to
+      # kalenderår:
+      
+      ,aar_uke = ifelse( 
+        # hvis uke 01 er i desember...
+        test = uke == "01" & maaned_nr == "12"
+        # .. så sier vi at uken tilhører det seneste av de to årene som uke 01
+        # er spredt over (uke 01 i desember 2019 blir til 2020-01)
+        , yes = paste0( as.integer(year(ProsedyreDato)) + 1, "-", uke )
+        , no = paste0(aar, "-", uke )
+      )
+      ,aar_uke = ifelse( 
+        # hvis uke 52 eller 53 er i januar...
+        test = uke %in% c("52", "53") & maaned_nr == "01"
+        # ...sier vi at hele uken tilhører det tidligste av de to årene som uke
+        # 52/53 er spredt over (1. januar 2017 som er i uke 52 blir til 2016-52)
+        , yes = paste0( as.integer(year(ProsedyreDato)) - 1, "-", uke )
+        , no = aar_uke
+      )
+      ,aar_uke = as.ordered( aar_uke )
     )
   
   
-  # Utledet variabel - ant_stent_ila_forlop = antall stenter satt inn ila ett forløp
+  # Utledet variabel:
+  # ant_stent_ila_forlop = antall stenter satt inn ila ett forløp
   
   ant_stent <- SS  %>%
     group_by(Sykehusnavn) %>%
     count( ForlopsID, wt = !is.na( StentType ) )
   
   # Har nå en df med Sykehusnavn, ForlopsID og n = antall rader tilhørende et
-  # forløp hvor StentType er oppgitt (!is.na() == TRUE når det er satt inn stent)
+  # forløp hvor StentType er oppgitt (!is.na() == TRUE når det er satt inn
+  # stent)
 
   # Endrer navn på "n":
   names( ant_stent )[3] <- "ant_stent_ila_forlop"
@@ -217,8 +232,8 @@ FROM
     arrange( Sykehusnavn, ForlopsID)
   
   # For hver rad blir det oppgitt antall stenter som ble satt inn ila det
-  # forløpet (ett forløp på ett sykehus kan ha flere rader hvor hver rad oppgir det totale
-  # antallet)
+  # forløpet (ett forløp på ett sykehus kan ha flere rader hvor hver rad oppgir
+  # det totale antallet)
   
   
   SS

--- a/R/getLocalSSData.R
+++ b/R/getLocalSSData.R
@@ -109,7 +109,10 @@ FROM
         (AvdRESH == 106944) & ( as.Date(ProsedyreDato) >= "2015-01-01" ) # LHLGardermoen
       ) | (
         (AvdRESH == 108141) & ( as.Date(ProsedyreDato) >= "2016-01-01" ) # Ahus
-      ))
+      ) | (
+        (AvdRESH == 4210141) & ( as.Date(ProsedyreDato) >= "2020-02-10" ) # Bodø
+      )
+    )
   
   
   # Gjøre kategoriske variabler om til factor:

--- a/R/getLocalSSData.R
+++ b/R/getLocalSSData.R
@@ -72,11 +72,9 @@ FROM
   
   # Gjor datoer om til dato-objekt:
   SS %<>%
-    mutate(
-      FodselsDato = ymd( FodselsDato )
-      ,HovedDato = ymd( HovedDato )
-      ,ProsedyreDato = ymd( ProsedyreDato )
-    )
+    mutate_at(
+      vars( ends_with("dato", ignore.case = TRUE) ), list( ymd )
+    ) 
   
   
   # Endre Sykehusnavn til kortere versjoner:

--- a/R/getMKData.R
+++ b/R/getMKData.R
@@ -102,8 +102,12 @@ FROM
   MK %<>%
     mutate(
       Sykehusnavn = ifelse( Sykehusnavn == "Haukeland" , "HUS" , Sykehusnavn ) ,
-      Sykehusnavn = ifelse( Sykehusnavn %in% c("St.Olav", "St. Olav") , "St.Olavs"  , Sykehusnavn ) ,
-      Sykehusnavn = ifelse( Sykehusnavn == "Akershus universitetssykehus HF" , "Ahus" , Sykehusnavn )
+      Sykehusnavn = ifelse( 
+        Sykehusnavn %in% c("St.Olav", "St. Olav") , "St.Olavs"  , Sykehusnavn 
+      ) ,
+      Sykehusnavn = ifelse( 
+        Sykehusnavn == "Akershus universitetssykehus HF" , "Ahus" , Sykehusnavn 
+      )
     )
   
   
@@ -213,33 +217,45 @@ FROM
   
   # Utledete variabler:
   MK %<>% 
-    mutate( 
+    mutate(
       
-      dager_mellom_prosedyre_og_utskr = as.numeric( difftime(  UtskrDato, ProsedyreDato, units = "days" ) )
+      dager_mellom_prosedyre_og_utskr = as.numeric( 
+        difftime(  UtskrDato, ProsedyreDato, units = "days" ) 
+      )
       
       # Div. tidsvariabler:
       #
       # Kalenderår for ProsedyreDato:
-      ,year = as.ordered( year( ProsedyreDato ))
-      ,aar = year
+      ,aar = as.ordered( year( ProsedyreDato ))
       # Måned:
       # (månedsnr er tosifret; 01, 02, ....)
       ,maaned_nr = as.ordered( sprintf(fmt = "%02d", month( ProsedyreDato ) ))
-      ,maaned = as.ordered( paste0( year, "-", maaned_nr) )
+      ,maaned = as.ordered( paste0( aar, "-", maaned_nr) )
       # Kvartal:
       ,kvartal = quarter( ProsedyreDato, with_year = TRUE )
-      # kvartal = as.factor( gsub( "\\.", "-", kvartal) ),
+      # kvartal = as.factor( gsub( "\\.", "-", kvartal) )
       ,kvartal = as.ordered( gsub( "[[:punct:]]", "-Q", kvartal) )
       # Uketall:
       ,uke = as.ordered( sprintf(fmt = "%02d", isoweek( ProsedyreDato ) ))
-      # Variabel "yyyy-ukenummer" som tar høyde for uketall som befinner seg i to kalenderår:
-      ,aar_uke = ifelse( test = uke == "01" & maaned_nr == "12", # hvis uke 01 i desember...
-                        yes = paste0( as.integer(year(ProsedyreDato)) + 1, "-", uke ), # ..sier vi at year er det seneste året som den uken tilhørte
-                        no = paste0(aar, "-", uke )
+      
+      # Variabel med "yyyy-ukenummer" som tar høyde for uketall spredt over to
+      # kalenderår:
+      
+      ,aar_uke = ifelse( 
+        # hvis uke 01 er i desember...
+        test = uke == "01" & maaned_nr == "12"
+        # .. så sier vi at uken tilhører det seneste av de to årene som uke 01
+        # er spredt over (uke 01 i desember 2019 blir til 2020-01)
+        , yes = paste0( as.integer(year(ProsedyreDato)) + 1, "-", uke )
+        , no = paste0(aar, "-", uke )
       )
-      ,aar_uke = ifelse( test = uke %in% c("52", "53") & maaned_nr == "01", # hvis uke 52 eller 53 i januar...
-                        yes = paste0( as.integer(year(ProsedyreDato)) - 1, "-", uke ), # ...sier vi at hele uken tilhører det tidligste året
-                        no = aar_uke
+      ,aar_uke = ifelse( 
+        # hvis uke 52 eller 53 er i januar...
+        test = uke %in% c("52", "53") & maaned_nr == "01"
+        # ...sier vi at hele uken tilhører det tidligste av de to årene som uke
+        # 52/53 er spredt over (1. januar 2017 som er i uke 52 blir til 2016-52)
+        , yes = paste0( as.integer(year(ProsedyreDato)) - 1, "-", uke )
+        , no = aar_uke
       )
       ,aar_uke = as.ordered( aar_uke )
     )

--- a/R/getMKData.R
+++ b/R/getMKData.R
@@ -81,13 +81,9 @@ FROM
 
   # Gjor datoer om til dato-objekt:
   MK %<>%
-    mutate(
-      Dodsdato = ymd( Dodsdato )
-      ,ProsedyreDato = ymd( ProsedyreDato )
-      ,FodselsDato = ymd( FodselsDato ) # FO
-      ,HovedDato = ymd( HovedDato ) # FO
-      ,UtskrDato = ymd( UtskrDato )
-    )
+    mutate_at(
+      vars( ends_with("dato", ignore.case = TRUE) ), list( ymd )
+    ) 
   
   
   # Endre Sykehusnavn til kortere versjoner:

--- a/R/getMKData.R
+++ b/R/getMKData.R
@@ -78,15 +78,7 @@ FROM
   MK <- left_join(MK, FO, by = c("ForlopsID", "AvdRESH"),
                   suffix = c("", ".FO"))
   
-  
-  # Klokkeslett med "01.01.70 " som prefix fikses:
-  MK %<>%
-    mutate(
-      Avslutningstid = gsub( "01.01.70 " , "" , Avslutningstid ) ,
-      Punksjonstid = gsub( "01.01.70 " , "" , Punksjonstid )
-    )
-  
-  
+
   # Gjor datoer om til dato-objekt:
   MK %<>%
     mutate(

--- a/R/getPSData.R
+++ b/R/getPSData.R
@@ -84,8 +84,12 @@ FROM
   PS %<>%
     mutate(
       Sykehusnavn = ifelse( Sykehusnavn == "Haukeland" , "HUS" , Sykehusnavn ) ,
-      Sykehusnavn = ifelse( Sykehusnavn %in% c("St.Olav", "St. Olav") , "St.Olavs"  , Sykehusnavn ) ,
-      Sykehusnavn = ifelse( Sykehusnavn == "Akershus universitetssykehus HF" , "Ahus" , Sykehusnavn )
+      Sykehusnavn = ifelse( 
+        Sykehusnavn %in% c("St.Olav", "St. Olav") , "St.Olavs"  , Sykehusnavn 
+      ) ,
+      Sykehusnavn = ifelse(
+        Sykehusnavn == "Akershus universitetssykehus HF" , "Ahus" , Sykehusnavn 
+      )
     )
   
 
@@ -99,52 +103,85 @@ FROM
       # Div. tidsvariabler:
       
       # Basert på PasInklDato:
+      
       # Kalenderår:
-      year_pasientinklusjon = as.ordered( year( PasInklDato ))
-      ,aar_pasientinklusjon = year_pasientinklusjon
+      aar_pasientinklusjon = as.ordered( year( PasInklDato ))
       # Måned:
       # (månedsnr er tosifret; 01, 02, ....)
-      ,maaned_nr_pasientinklusjon = as.ordered( sprintf(fmt = "%02d", month( PasInklDato ) ))
-      ,maaned_pasientinklusjon = as.ordered( paste0( year_pasientinklusjon, "-", maaned_nr_pasientinklusjon) )
+      ,maaned_nr_pasientinklusjon = 
+        as.ordered( sprintf(fmt = "%02d", month( PasInklDato ) ))
+      ,maaned_pasientinklusjon = 
+        as.ordered( 
+          paste0( aar_pasientinklusjon, "-", maaned_nr_pasientinklusjon) 
+        )
       # Kvartal:
       ,kvartal_pasientinklusjon = quarter( PasInklDato, with_year = TRUE )
-      # kvartal = as.factor( gsub( "\\.", "-", kvartal) )
-      ,kvartal_pasientinklusjon = as.ordered( gsub( "[[:punct:]]", "-Q", kvartal_pasientinklusjon) )
+      ,kvartal_pasientinklusjon = 
+        as.ordered( gsub( "[[:punct:]]", "-Q", kvartal_pasientinklusjon) )
       # Uketall:
-      ,uke_pasientinklusjon = as.ordered( sprintf(fmt = "%02d", isoweek( PasInklDato ) ))
-      # Variabel "yyyy-ukenummer" som tar høyde for uketall som befinner seg i to kalenderår:
-      ,aar_uke_pasientinklusjon = ifelse( test = uke_pasientinklusjon == "01" & maaned_nr_pasientinklusjon == "12", # hvis uke 01 i desember...
-                         yes = paste0( as.integer(year(PasInklDato)) + 1, "-", uke_pasientinklusjon ), # ..sier vi at year er det seneste året som den uken tilhørte
-                         no = paste0(aar_pasientinklusjon, "-", uke_pasientinklusjon )
+      ,uke_pasientinklusjon = 
+        as.ordered( sprintf(fmt = "%02d", isoweek( PasInklDato ) ))
+      
+      # Variabel med "yyyy-ukenummer" som tar høyde for uketall spredt over to
+      # kalenderår:
+      ,aar_uke_pasientinklusjon = ifelse( 
+        # hvis uke 01 er i desember...
+        test = uke_pasientinklusjon == "01" & maaned_nr_pasientinklusjon == "12" 
+        # .. så sier vi at uken tilhører det seneste av de to årene som uke 01
+        # er spredt over (uke 01 i desember 2019 blir til 2020-01)
+        ,yes = 
+          paste0( as.integer(year(PasInklDato)) + 1, "-", uke_pasientinklusjon )
+        ,no = paste0(aar_pasientinklusjon, "-", uke_pasientinklusjon )
       )
-      ,aar_uke_pasientinklusjon = ifelse( test = uke_pasientinklusjon %in% c("52", "53") & maaned_nr_pasientinklusjon == "01", # hvis uke 52 eller 53 i januar...
-                         yes = paste0( as.integer(year(PasInklDato)) - 1, "-", uke_pasientinklusjon ), # ...sier vi at hele uken tilhører det tidligste året
-                         no = aar_uke_pasientinklusjon
+      ,aar_uke_pasientinklusjon = ifelse( 
+        # hvis uke 52 eller 53 er i januar...
+        test = uke_pasientinklusjon %in% c("52", "53") & 
+          maaned_nr_pasientinklusjon == "01"
+        # ...sier vi at hele uken tilhører det tidligste av de to årene som uke
+        # 52/53 er spredt over (1. januar 2017 som er i uke 52 blir til 2016-52)
+        ,yes = 
+          paste0( as.integer(year(PasInklDato)) - 1, "-", uke_pasientinklusjon )
+        ,no = aar_uke_pasientinklusjon
       )
       ,aar_uke_pasientinklusjon = as.ordered( aar_uke_pasientinklusjon )
 
       # Basert på StudieStartDato:
+      
       # Kalenderår:
-      ,year_studiestart = as.ordered( year( StudieStartDato ))
-      ,aar_studiestart = year_studiestart
+      ,aar_studiestart = as.ordered( year( StudieStartDato ))
       # Måned:
       # (månedsnr er tosifret; 01, 02, ....)
-      ,maaned_nr_studiestart = as.ordered( sprintf(fmt = "%02d", month( StudieStartDato ) ))
-      ,maaned_studiestart = as.ordered( paste0( year_studiestart, "-", maaned_nr_studiestart) )
+      ,maaned_nr_studiestart = 
+        as.ordered( sprintf(fmt = "%02d", month( StudieStartDato ) ))
+      ,maaned_studiestart = 
+        as.ordered( paste0( aar_studiestart, "-", maaned_nr_studiestart) )
       # Kvartal:
       ,kvartal_studiestart = quarter( StudieStartDato, with_year = TRUE )
-      # kvartal = as.factor( gsub( "\\.", "-", kvartal) )
-      ,kvartal_studiestart = as.ordered( gsub( "[[:punct:]]", "-Q", kvartal_studiestart) )
+      ,kvartal_studiestart = 
+        as.ordered( gsub( "[[:punct:]]", "-Q", kvartal_studiestart) )
       # Uketall:
-      ,uke_studiestart = as.ordered( sprintf(fmt = "%02d", isoweek( StudieStartDato ) ))
-      # Variabel "yyyy-ukenummer" som tar høyde for uketall som befinner seg i to kalenderår:
-      ,aar_uke_studiestart = ifelse( test = uke_studiestart == "01" & maaned_nr_studiestart == "12", # hvis uke 01 i desember...
-                         yes = paste0( as.integer(year(StudieStartDato)) + 1, "-", uke_studiestart ), # ..sier vi at year er det seneste året som den uken tilhørte
-                         no = paste0(aar_studiestart, "-", uke_studiestart )
+      ,uke_studiestart = 
+        as.ordered( sprintf(fmt = "%02d", isoweek( StudieStartDato ) ))
+      # Variabel med "yyyy-ukenummer" som tar høyde for uketall spredt over to
+      # kalenderår:
+      ,aar_uke_studiestart = ifelse( 
+        # hvis uke 01 er i desember...
+        test = uke_studiestart == "01" & maaned_nr_studiestart == "12"
+        # .. så sier vi at uken tilhører det seneste av de to årene som uke 01
+        # er spredt over (uke 01 i desember 2019 blir til 2020-01)
+        ,yes = 
+          paste0( as.integer(year(StudieStartDato)) + 1, "-", uke_studiestart )
+        ,no = paste0(aar_studiestart, "-", uke_studiestart )
       )
-      ,aar_uke_studiestart = ifelse( test = uke_studiestart %in% c("52", "53") & maaned_nr_studiestart == "01", # hvis uke 52 eller 53 i januar...
-                         yes = paste0( as.integer(year(StudieStartDato)) - 1, "-", uke_studiestart ), # ...sier vi at hele uken tilhører det tidligste året
-                         no = aar_uke_studiestart
+      ,aar_uke_studiestart = ifelse( 
+        # hvis uke 52 eller 53 er i januar...
+        test = 
+          uke_studiestart %in% c("52", "53") & maaned_nr_studiestart == "01"
+        # ...sier vi at hele uken tilhører det tidligste av de to årene som uke
+        # 52/53 er spredt over (1. januar 2017 som er i uke 52 blir til 2016-52)
+        ,yes = 
+          paste0( as.integer(year(StudieStartDato)) - 1, "-", uke_studiestart )
+        ,no = aar_uke_studiestart
       )
       ,aar_uke_studiestart = as.ordered( aar_uke_studiestart )
     )

--- a/R/getPSData.R
+++ b/R/getPSData.R
@@ -70,14 +70,9 @@ FROM
 
   # Gjor datoer om til dato-objekt:
   PS %<>%
-    mutate(
-      FodselsDato = ymd( FodselsDato )
-      ,PasInklDato = ymd( PasInklDato )
-      ,PasAvsluttDato = ymd( PasAvsluttDato )
-      ,StudieStartDato = ymd( StudieStartDato )
-      ,StudieAvsluttDato = ymd( StudieAvsluttDato )
-      ,StudieOppflgAvslDato = ymd( StudieOppflgAvslDato )
-    )
+    mutate_at(
+      vars( ends_with("dato", ignore.case = TRUE) ), list( ymd )
+    ) 
   
   
   # Endre Sykehusnavn til kortere versjoner:

--- a/R/getPSData.R
+++ b/R/getPSData.R
@@ -88,16 +88,7 @@ FROM
       Sykehusnavn = ifelse( Sykehusnavn == "Akershus universitetssykehus HF" , "Ahus" , Sykehusnavn )
     )
   
-  
 
-  # Gjøre kategoriske variabler om til factor:
-  # (ikke fullstendig, må legge til mer etter hvert)
-  PS %<>%
-    mutate(
-      StudieNavn = addNA( StudieNavn, ifany = TRUE )
-      ,ProsedyreType = addNA( ProsedyreType , ifany = TRUE )
-      ,StudieStatus = addNA( StudieStatus , ifany = TRUE )
-    )
   
   
   


### PR DESCRIPTION
* rettet feil der data fra Bodø ikke var tilgjengelig i Utforsker (#58 )
  
* slettet linjer fra `getLocalXXData()`-funksjoner hvor kolonner ble konvertert til factors med levels med alfabetisk rekkefølge. Dette var unødvendig funksjonalitet da `rpivotTable` gjør dette automatisk. Beholdt factors med egenspesifisert, ikke-alfabetisk rekkefølge selv om disse omgjøres til alfabetisk av `rpivotTable` med mindre man bruker argumentet `sorters`. Dette må ev. komme senere.
  
* forbedret lesbarheten til `getLocalXXData()`-funksjonene ved å ha maks 80 tegn per linje
  
* gjorde konverteringen fra character til Date mer robust ved å bruke 
`mutate_at( ends_with( "dato" ), ... )` i stedet for å "hardkode" navnene til kolonnene med datoer.  