### PR TITLE
Bugfix #36

### DIFF
--- a/R/getDataDump.R
+++ b/R/getDataDump.R
@@ -80,6 +80,21 @@ WHERE
   }
   
   
+  # Datadumper som skal filtreres på bakgrunn av PasInklDato:
+  # PS
+  if( tableName %in% c( "PasienterStudier" ) 
+  ){
+    query <- paste0("
+SELECT
+  *
+FROM 
+  ", tableName, "
+WHERE 
+  PasInklDato >= '", fromDate, "' AND PasInklDato <= '", toDate, "';"
+    )
+  }
+  
+  
 
   
   if ("session" %in% names(list(...))) {
@@ -93,7 +108,7 @@ WHERE
   
   
   # Henter FO, som har felt som skal legges til tabellen (med unntak av når tabellene som
-  # skal lastes ned er FO, SO, eller PasientStudier)
+  # skal lastes ned er FO eller SO)
     if( tableName %in% c( "AndreProsedyrerVar"
                           , "AnnenDiagnostikkVar"
                           , "AortaklaffVar"
@@ -101,6 +116,7 @@ WHERE
                           , "AngioPCIVar"
                           , "CTAngioVar"
                           , "MitralklaffVar"
+                          , "PasienterStudier"
                           , "SegmentStent" )
   ){
     
@@ -327,6 +343,31 @@ WHERE
         )
       
       tab <- left_join(tab, FO, by = c("ForlopsID", "AvdRESH")
+                       ,suffix = c("", ".FO") 
+                      )
+    }
+    
+    
+    # PS ----
+    if( tableName %in% c( "PasienterStudier" ) ){
+      
+      FO %<>% 
+        select(
+          # Nøkler:
+          AvdRESH
+          ,PasientID
+          # Variablene som legges til:
+          ,Sykehusnavn
+          ,FodselsDato
+          ,Kommune
+          ,KommuneNr
+          ,Fylke
+          ,Fylkenr
+          ,PasientKjonn
+          ,PasientAlder
+        )
+      
+      tab <- left_join(tab, FO, by = c("PasientID", "AvdRESH")
                        ,suffix = c("", ".FO") 
                       )
     }

--- a/R/getDataDump.R
+++ b/R/getDataDump.R
@@ -16,7 +16,7 @@
 getDataDump <- function(registryName, tableName, fromDate, toDate, ...) {
   
   # Datadumper som skal filtreres på bakgrunn av ProsedyreDato:
-  # AnP, AD, AK, AP, & SS
+  # AnP, AD, AK, AP, MK & SS
   if( tableName %in% c( "AndreProsedyrerVar"
                         , "AnnenDiagnostikkVar"
                         , "AortaklaffVar"

--- a/R/getDataDump.R
+++ b/R/getDataDump.R
@@ -21,6 +21,7 @@ getDataDump <- function(registryName, tableName, fromDate, toDate, ...) {
                         , "AnnenDiagnostikkVar"
                         , "AortaklaffVar"
                         , "AngioPCIVar"
+                        , "MitralklaffVar"
                         , "SegmentStent") 
   ){
     query <- paste0("
@@ -99,6 +100,7 @@ WHERE
                           , "AortaklaffOppfVar"
                           , "AngioPCIVar"
                           , "CTAngioVar"
+                          , "MitralklaffVar"
                           , "SegmentStent" )
   ){
     
@@ -293,6 +295,39 @@ WHERE
                                        ,"PasientID"
                                        , "AvdRESH"),
                       suffix = c("", ".FO") 
+                      )
+    }
+    
+    
+    # MK ----
+    if( tableName %in% c( "MitralklaffVar" ) ){
+      
+      FO %<>% 
+        select(
+          # Nøkler:
+          AvdRESH
+          ,ForlopsID
+          # Variablene som legges til:
+          ,Sykehusnavn
+          ,PasientID
+          ,KommuneNr
+          ,Kommune
+          ,Fylke
+          ,Fylkenr
+          ,PasientKjonn
+          ,PasientAlder
+          ,BasisRegStatus
+          ,ForlopsType1
+          ,ForlopsType2
+          ,KobletForlopsID
+          ,HovedDato
+          ,FodselsDato
+          ,Avdod
+          ,AvdodDato
+        )
+      
+      tab <- left_join(tab, FO, by = c("ForlopsID", "AvdRESH")
+                       ,suffix = c("", ".FO") 
                       )
     }
     

--- a/R/getDataDump.R
+++ b/R/getDataDump.R
@@ -64,6 +64,21 @@ WHERE
   }
   
   
+  # Datadumper som skal filtreres på bakgrunn av BasisProsedyreDato:
+  # AKOppf
+  if( tableName %in% c( "AortaklaffOppfVar" ) 
+  ){
+    query <- paste0("
+SELECT
+  *
+FROM 
+  ", tableName, "
+WHERE 
+  BasisProsedyreDato >= '", fromDate, "' AND BasisProsedyreDato <= '", toDate, "';"
+    )
+  }
+  
+  
 
   
   if ("session" %in% names(list(...))) {
@@ -81,6 +96,7 @@ WHERE
     if( tableName %in% c( "AndreProsedyrerVar"
                           , "AnnenDiagnostikkVar"
                           , "AortaklaffVar"
+                          , "AortaklaffOppfVar"
                           , "AngioPCIVar"
                           , "CTAngioVar"
                           , "SegmentStent" )
@@ -171,6 +187,43 @@ WHERE
           ,ForlopsType2
           ,KobletForlopsID
           ,HovedDato
+        )
+      
+      tab <- left_join(tab, FO, by = c("ForlopsID", "AvdRESH")
+                       , suffix = c("", ".FO") 
+      )
+    }
+    
+    
+    # AKOppf ----
+    if( tableName %in% c( "AortaklaffOppfVar" )){
+      
+      FO %<>% 
+        select(
+          # Nøkler:
+          AvdRESH
+          ,ForlopsID
+          # Variablene som legges til:
+          ,Sykehusnavn
+          ,PasientID
+          ,PasientKjonn
+          ,PasientAlder
+          ,BasisRegStatus
+          ,ForlopsType1
+          ,ForlopsType2
+          ,KobletForlopsID
+          ,HovedDato
+          ,Kommune
+          ,KommuneNr
+          ,Fylke
+          ,Fylkenr
+          ,FodselsDato
+          ,Avdod
+          ,AvdodDato
+          ,ErOppflg
+          ,OppflgStatus
+          ,OppflgSekNr
+          ,OppflgRegStatus
         )
       
       tab <- left_join(tab, FO, by = c("ForlopsID", "AvdRESH")

--- a/R/getDataDump.R
+++ b/R/getDataDump.R
@@ -133,6 +133,7 @@ WHERE
           ,ForlopsID
           # Variablene som legges til:
           ,PasientID
+          ,PasientAlder
           ,Kommune
           ,KommuneNr
           ,Fylke

--- a/R/getDataDump.R
+++ b/R/getDataDump.R
@@ -16,8 +16,9 @@
 getDataDump <- function(registryName, tableName, fromDate, toDate, ...) {
   
   # Datadumper som skal filtreres på bakgrunn av ProsedyreDato:
-  # AnP, AK, AP, & SS
+  # AnP, AD, AK, AP, & SS
   if( tableName %in% c( "AndreProsedyrerVar"
+                        , "AnnenDiagnostikkVar"
                         , "AortaklaffVar"
                         , "AngioPCIVar"
                         , "SegmentStent") 
@@ -78,6 +79,7 @@ WHERE
   # Henter FO, som har felt som skal legges til tabellen (med unntak av når tabellene som
   # skal lastes ned er FO, SO, eller PasientStudier)
     if( tableName %in% c( "AndreProsedyrerVar"
+                          , "AnnenDiagnostikkVar"
                           , "AortaklaffVar"
                           , "AngioPCIVar"
                           , "CTAngioVar"
@@ -110,6 +112,31 @@ WHERE
           ,Fylkenr
           ,PasientKjonn
           ,PasientAlder
+          ,ForlopsType1
+          ,ForlopsType2
+          ,KobletForlopsID
+          ,HovedDato
+        )
+      
+      tab <- left_join(tab, FO, by = c("ForlopsID", "AvdRESH")
+                       , suffix = c("", ".FO") 
+                       )
+    }
+    
+    # AD ----
+    if( tableName %in% c( "AnnenDiagnostikkVar" )){
+      
+      FO %<>% 
+        select(
+          # Nøkler:
+          AvdRESH
+          ,ForlopsID
+          # Variablene som legges til:
+          ,PasientID
+          ,Kommune
+          ,KommuneNr
+          ,Fylke
+          ,Fylkenr
           ,ForlopsType1
           ,ForlopsType2
           ,KobletForlopsID

--- a/inst/shinyApps/noric/ui.R
+++ b/inst/shinyApps/noric/ui.R
@@ -115,6 +115,7 @@ ui <- tagList(
                                    "AnnenDiagnostikkVar",
                                    "AngioPCIVar",
                                    "AortaklaffVar",
+                                   "AortaklaffOppfVar",
                                    "CTAngioVar",
                                    "ForlopsOversikt",
                                    "SegmentStent",

--- a/inst/shinyApps/noric/ui.R
+++ b/inst/shinyApps/noric/ui.R
@@ -119,6 +119,7 @@ ui <- tagList(
                                    "CTAngioVar",
                                    "ForlopsOversikt",
                                    "MitralklaffVar",
+                                   "PasienterStudier",
                                    "SegmentStent",
                                    "SkjemaOversikt")),
                      dateRangeInput("dumpDateRange", "Velg periode:",

--- a/inst/shinyApps/noric/ui.R
+++ b/inst/shinyApps/noric/ui.R
@@ -112,6 +112,7 @@ ui <- tagList(
         sidebarPanel(width = 4,
                      selectInput("dumpDataSet", "Velg datasett:",
                                  c("AndreProsedyrerVar",
+                                   "AnnenDiagnostikkVar",
                                    "AngioPCIVar",
                                    "AortaklaffVar",
                                    "CTAngioVar",

--- a/inst/shinyApps/noric/ui.R
+++ b/inst/shinyApps/noric/ui.R
@@ -118,6 +118,7 @@ ui <- tagList(
                                    "AortaklaffOppfVar",
                                    "CTAngioVar",
                                    "ForlopsOversikt",
+                                   "MitralklaffVar",
                                    "SegmentStent",
                                    "SkjemaOversikt")),
                      dateRangeInput("dumpDateRange", "Velg periode:",


### PR DESCRIPTION
Har gjort endringer i `ui.R` og `getDataDump.R` som (forhåpentligvis) muliggjør nedlasting av de resterende tabellene/datadumpene som vi ikke rakk å ha med i releasen før jul. 

Tabellen _MitralklaffOppfVar_ har fortsatt ingen registreringer såvidt jeg vet, så den ble ikke tatt med i denne omgangen heller.

Vurderer det ikke som nødvendig med review fra @areedv for disse endringene da de ikke er særlig omfattende og benytter allerede eksisterende rammeverk. 