### PR TITLE
Minor updates ki report + Avdod

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: noric
 Title: Provide R Resources for NORIC at Rapporteket
-Version: 2.1.0
+Version: 2.1.1
 Authors@R: c(
   person("Kristina",
          "Skaare",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: noric
 Title: Provide R Resources for NORIC at Rapporteket
-Version: 2.1.1
+Version: 2.2.0
 Authors@R: c(
   person("Kristina",
          "Skaare",

--- a/R/getAKData.R
+++ b/R/getAKData.R
@@ -64,7 +64,9 @@ FROM
       .data$PasientAlder,
       .data$ForlopsType1,
       .data$ForlopsType2,
-      .data$KobletForlopsID
+      .data$KobletForlopsID,
+      .data$Avdod,
+      .data$AvdodDato
     )
 
 

--- a/R/getDataDump.R
+++ b/R/getDataDump.R
@@ -209,7 +209,9 @@ WHERE
           .data$ForlopsType1,
           .data$ForlopsType2,
           .data$KobletForlopsID,
-          .data$HovedDato
+          .data$HovedDato,
+          .data$Avdod,
+          .data$AvdodDato
         )
 
       tab <- dplyr::left_join(tab, fO,
@@ -274,14 +276,16 @@ WHERE
           .data$ForlopsType1,
           .data$ForlopsType2,
           .data$KobletForlopsID,
-          .data$HovedDato
+          .data$HovedDato,
+          .data$Avdod,
+          .data$AvdodDato
         )
 
       # Legger til variabler fra fO til AP:
       tab <- dplyr::left_join(tab, fO, by = c("AvdRESH",
-                                       "Sykehusnavn",
-                                       "PasientID",
-                                       "ForlopsID")
+                                              "Sykehusnavn",
+                                              "PasientID",
+                                              "ForlopsID")
       )
     }
 
@@ -306,7 +310,9 @@ WHERE
           .data$ForlopsType1,
           .data$ForlopsType2,
           .data$KobletForlopsID,
-          .data$HovedDato
+          .data$HovedDato,
+          .data$Avdod,
+          .data$AvdodDato
         )
 
       tab <- dplyr::left_join(tab, fO, by = c("ForlopsID",
@@ -403,9 +409,5 @@ WHERE
                               )
     }
   }
-
-  # Midlertidig fjerning av variabler i datadumpen
-  dplyr::select(tab, !tidyselect::contains(c("Avdod", "AvdodDato")))
-
 
 }

--- a/R/getLocalAPData.R
+++ b/R/getLocalAPData.R
@@ -54,7 +54,9 @@ FROM AngioPCIVar
       .data$PasientAlder,
       .data$ForlopsType1,
       .data$ForlopsType2,
-      .data$KobletForlopsID
+      .data$KobletForlopsID,
+      .data$Avdod,
+      .data$AvdodDato
     )
 
   # Legger til variabler fra fO til aP:

--- a/R/getLocalCTData.R
+++ b/R/getLocalCTData.R
@@ -54,7 +54,9 @@ FROM CTAngioVar
       .data$PasientKjonn,
       .data$PasientAlder,
       .data$ForlopsType1,
-      .data$ForlopsType2
+      .data$ForlopsType2,
+      .data$Avdod,
+      .data$AvdodDato
     )
 
   cT <- dplyr::left_join(cT, fO, by = c("ForlopsID",

--- a/R/getPivotDataSet.R
+++ b/R/getPivotDataSet.R
@@ -71,12 +71,6 @@ getPivotDataSet <- function(setId = "", registryName, singleRow = FALSE,
   }
 
 
-  #Fjerner Avdod og AvdodDato midlertidig for både SC og LC
-  if (!is.null(dat)) {
-    dat %<>% dplyr::select_if(!names(.) %in% c("Avdod", "AvdodDato"))
-  }
-
-
 
   #Fjerner variablene som ikke skal vises for LC
   if (userRole == "LC" && !is.null(dat)) {

--- a/inst/NORIC_kvalitetsindikator.Rmd
+++ b/inst/NORIC_kvalitetsindikator.Rmd
@@ -290,7 +290,7 @@ aP_nasjonalt %<>%
                               !is.na(.data$AdmissionType) &
                               !is.na(.data$TidsDiffSek) &
                               .data$TidsDiffSek > 0 & 
-                              .data$TidsDiffSek <= 14*24*60*60),
+                              .data$TidsDiffSek <= 14 * 24 * 60 * 60),
     true = "ja", 
     false = "nei", 
     missing = "nei"))

--- a/inst/NORIC_kvalitetsindikator.Rmd
+++ b/inst/NORIC_kvalitetsindikator.Rmd
@@ -1401,7 +1401,7 @@ innsnevring og vurdering av resultat etter PCI. Indikatoren angir andel
 pasienter der det er utført supplerende billeddiagnostikk under prosedyren. 
 Pasienter som tidligere har fått utført ACB-operasjon og pasienter som blir 
 behandlet for akutt hjerteinfarkt av typen STEMI er ikke medregnet i analysene.
-(Mål $\geq$ 40 %)
+(Mål $\geq$ 60 %)
 
 ```{r stentingVH, include=FALSE, eval=TRUE}
 

--- a/inst/NORIC_kvalitetsindikator.Rmd
+++ b/inst/NORIC_kvalitetsindikator.Rmd
@@ -290,7 +290,7 @@ aP_nasjonalt %<>%
                               !is.na(.data$AdmissionType) &
                               !is.na(.data$TidsDiffSek) &
                               .data$TidsDiffSek > 0 & 
-                              .data$TidsDiffSek <= 1814400),
+                              .data$TidsDiffSek <= 14*24*60*60),
     true = "ja", 
     false = "nei", 
     missing = "nei"))


### PR DESCRIPTION
- To mindre oppdatertinger i KI-rapporten jfr. årsrapporten for 2020-data
- Kobling mot døds-status i folkeregisteret fungerer nå i ny release av NORIC. Derfor er Utforsker  + Datadump nå tilrettelagt for å vise variablene Avdod og AvdodDato i AP, AK og CT. 