### PR TITLE
Fikse avdod avdod dato

### DIFF
--- a/R/getAKData.R
+++ b/R/getAKData.R
@@ -65,9 +65,8 @@ FROM
       .data$ForlopsType1,
       .data$ForlopsType2,
       .data$KobletForlopsID,
-      .data$Avdod,
-      .data$AvdodDato
-    )
+      .data$Avdod
+      )
 
 
   aK <- dplyr::left_join(aK, fO, by = c("ForlopsID", "AvdRESH"),

--- a/R/getDataDump.R
+++ b/R/getDataDump.R
@@ -210,8 +210,7 @@ WHERE
           .data$ForlopsType2,
           .data$KobletForlopsID,
           .data$HovedDato,
-          .data$Avdod,
-          .data$AvdodDato
+          .data$Avdod
         )
 
       tab <- dplyr::left_join(tab, fO,
@@ -276,9 +275,7 @@ WHERE
           .data$ForlopsType1,
           .data$ForlopsType2,
           .data$KobletForlopsID,
-          .data$HovedDato,
-          .data$Avdod,
-          .data$AvdodDato
+          .data$HovedDato
         )
 
       # Legger til variabler fra fO til AP:
@@ -310,9 +307,7 @@ WHERE
           .data$ForlopsType1,
           .data$ForlopsType2,
           .data$KobletForlopsID,
-          .data$HovedDato,
-          .data$Avdod,
-          .data$AvdodDato
+          .data$HovedDato
         )
 
       tab <- dplyr::left_join(tab, fO, by = c("ForlopsID",

--- a/R/getLocalAPData.R
+++ b/R/getLocalAPData.R
@@ -54,9 +54,7 @@ FROM AngioPCIVar
       .data$PasientAlder,
       .data$ForlopsType1,
       .data$ForlopsType2,
-      .data$KobletForlopsID,
-      .data$Avdod,
-      .data$AvdodDato
+      .data$KobletForlopsID
     )
 
   # Legger til variabler fra fO til aP:

--- a/R/getLocalCTData.R
+++ b/R/getLocalCTData.R
@@ -54,9 +54,7 @@ FROM CTAngioVar
       .data$PasientKjonn,
       .data$PasientAlder,
       .data$ForlopsType1,
-      .data$ForlopsType2,
-      .data$Avdod,
-      .data$AvdodDato
+      .data$ForlopsType2
     )
 
   cT <- dplyr::left_join(cT, fO, by = c("ForlopsID",


### PR DESCRIPTION
Fjerner doble variabler. 
Var ikke nødveldig å laste inn fra FO, de fantes allerede i tabellene AK, FO og AP. 
(Bare Dato i AK, derfor legges Avdod = ja/nei til)