### PR TITLE
Update .lintr

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,4 +1,4 @@
-linters: with_defaults(
+linters: linters_with_defaults(
   object_name_linter(c("camelCase", "snake_case")),
   cyclocomp_linter(complexity_limit = 35),
   line_length_linter(80))


### PR DESCRIPTION
Lintr feilet med følgende feilmelding:
> Function with_defaults was deprecated in lintr version 3.0.0. Use linters_with_defaults or modify_defaults instead.