### PR TITLE
Bugfix2024 duplicate varnames in SQL

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: noric
 Title: Provide R Resources for NORIC at Rapporteket
-Version: 2.15.4
+Version: 2.15.5
 Authors@R: c(
   person("Kristina",
          "Skaare",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# noric 2.15.5 bugfix dupliserte variabelnavn
+RMariaDB vil ikke lenger har dupliserte variabelnavn. Ryddet opp i SQL 
+for AK-tabellen.
+
 # noric 2.15.4 Buxfix nytt år
 For TAVI rapporten. Når kun en måned i inneværende år, tvinge string-format på 
 label til cumulative plot. Tvinge y-aksen til cumplot til å starte på 0. 

--- a/R/getData.R
+++ b/R/getData.R
@@ -169,7 +169,6 @@ getAk <- function(registryName, fromDate, toDate, singleRow,
 SELECT
     AortaklaffVar.*,
     ForlopsOversikt.Sykehusnavn,
-    ForlopsOversikt.PasientID,
     ForlopsOversikt.FodselsDato,
     ForlopsOversikt.Kommune,
     ForlopsOversikt.KommuneNr,
@@ -832,7 +831,7 @@ getTaviProm <- function(registryName, fromDate, toDate, singleRow, ...){
   if (is.null(toDate)) {
     toDate <- noric::getLatestEntry(registryName)
   }
-
+  
   
   queryAk <- paste0("
 SELECT
@@ -859,7 +858,7 @@ WHERE
     ProsedyreDato <= '", toDate, "'"
   )
   
-    
+  
   # Ask for all variables from PROM
   queryProm <- paste0("
 SELECT

--- a/inst/NORIC_tavi_report.Rmd
+++ b/inst/NORIC_tavi_report.Rmd
@@ -476,14 +476,16 @@ ggplot2::ggplot(df_cumplot) +
       periode_data$sisteHeleYear:periode_data$nyesteRegYear), 
     breaks = periode_data$sisteHeleYear:periode_data$nyesteRegYear) +
   
-  ggplot2::geom_label(mapping = ggplot2::aes(x= 12,
-                                             y = tot_fjor * 0.95,
-                                             label = tot_fjor) ,
-                     colour = colPrimary[3]) +
+  ggplot2::annotate(geom = "label", 
+                    x= 12,
+                    y = tot_fjor * 0.95,
+                    label = tot_fjor,
+                    colour = colPrimary[3]) +
 
-   ggplot2::geom_label(mapping = ggplot2::aes(x= periode_data$nyesteRegMnd,
-                                             y = tot_aar * 0.95,
-                                             label = tot_aar),
+     ggplot2::annotate(geom = "label", 
+                       x= periode_data$nyesteRegMnd,
+                       y = tot_aar * 0.95,
+                       label = tot_aar,
                      colour = colKontrast) +
 
   ggplot2::xlab("") + 

--- a/inst/NORIC_tavi_report.Rmd
+++ b/inst/NORIC_tavi_report.Rmd
@@ -615,9 +615,9 @@ if (params$tableFormat == "html") {
 
 
 
-<!-- `r if(params$tableFormat !="latex") {"<!--"}` -->
-<!-- \newpage -->
-<!-- `r if(params$tableFormat !="latex") {"-->"}` -->
+`r if(params$tableFormat !="latex") {"<!--"}`
+\newpage
+`r if(params$tableFormat !="latex") {"-->"}`
 
 
 


### PR DESCRIPTION
Feil siden 22/08-2024: 
* Bulletin/Staging data fungerte ikke
* Rapport for kvalitetsindikator var umulig å generere
* Aortaklaff rappporten var umulig å lage

RMariaDB vil ikke lenger har dupliserte variabelnavn. Ryddet opp i SQL for AK-tabellen.
