### PR TITLE
Fikset logikk i vis/skjul faner

### DIFF
--- a/dev/renv.R
+++ b/dev/renv.R
@@ -1,5 +1,5 @@
 
-Sys.setenv(FALK_EXTENDED_USER_RIGHTS= "[{\"A\":86,\"R\":\"SC\",\"U\":101619},{\"A\":86,\"R\":\"LU\",\"U\":101619},{\"A\":86,\"R\":\"SC\",\"U\":102966},{\"A\":86,\"R\":\"LU\",\"U\":102966},{\"A\":86,\"R\":\"SC\",\"U\":0}]")
+Sys.setenv(FALK_EXTENDED_USER_RIGHTS= "[{\"A\":86,\"R\":\"LU\",\"U\":101619},{\"A\":86,\"R\":\"SC\",\"U\":101619},{\"A\":86,\"R\":\"SS\",\"U\":102966},{\"A\":86,\"R\":\"LU\",\"U\":102966},{\"A\":86,\"R\":\"SC\",\"U\":0}]")
 Sys.setenv(MYSQL_DB_LOG="db_log")
 Sys.setenv(MYSQL_DB_AUTOREPORT="db_autoreport")
 Sys.setenv(MYSQL_DB_DATA="noric_unn,noric_bodoe")

--- a/inst/shinyApps/noric/server.R
+++ b/inst/shinyApps/noric/server.R
@@ -38,46 +38,43 @@ shinyServer(function(input, output, session) {
 
   # Hide tabs
   ## when role is 'LU' or some tabs for role 'LC'
-  shiny::observeEvent(user$role(), {
-    shiny::hideTab(inputId = "tabs", target = "Utforsker")
-    shiny::hideTab(inputId = "tabs", target = "Datadump")
-    shiny::hideTab(inputId = "tabs", target = "Verktøy")
-    shiny::hideTab(inputId = "tabs", target = "Angiografør/Operatør")
-    shiny::hideTab(inputId = "tabs", target = "Kodebok")
-    shiny::hideTab(inputId = "tabs", target = "Nedlasting rapporter")
+  shiny::observeEvent(list(user$role(), user$org()), {
+    shiny::showTab(inputId = "tabs", target = "Utforsker")
+    shiny::showTab(inputId = "tabs", target = "Datadump")
+    shiny::showTab(inputId = "tabs", target = "Verktøy")
+    shiny::showTab(inputId = "tabs", target = "Angiografør/Operatør")
+    shiny::showTab(inputId = "tabs", target = "Kodebok")
+    shiny::showTab(inputId = "tabs", target = "Nedlasting rapporter")
+    shiny::showTab(inputId = "tabs", target = "Prosedyrer")
+    shiny::showTab(inputId = "tabs", target = "Månedsrapporter")
+    shiny::showTab(inputId = "tabs", target = "Abonnement")
+    shiny::showTab(inputId = "tabs", target = "Utsending")
+    shiny::showTab(inputId = "tabs", target = "Bruksstatistikk")
+    shiny::showTab(inputId = "tabs", target = "Aortaklaff")
 
-    if (shiny::req(user$role()) == "LC") {
-      shiny::showTab(inputId = "tabs", target = "Utforsker")
-      shiny::showTab(inputId = "tabs", target = "Kodebok")
+    if (shiny::req(user$role()) == "LU") {
+      shiny::hideTab(inputId = "tabs", target = "Utforsker")
+      shiny::hideTab(inputId = "tabs", target = "Datadump")
+      shiny::hideTab(inputId = "tabs", target = "Verktøy")
+      shiny::hideTab(inputId = "tabs", target = "Angiografør/Operatør")
+      shiny::hideTab(inputId = "tabs", target = "Kodebok")
+      shiny::hideTab(inputId = "tabs", target = "Nedlasting rapporter")
+    } else if (shiny::req(user$role()) == "LC") {
+      shiny::hideTab(inputId = "tabs", target = "Datadump")
+      shiny::hideTab(inputId = "tabs", target = "Verktøy")
+      shiny::hideTab(inputId = "tabs", target = "Nedlasting rapporter")
+      shiny::hideTab(inputId = "tabs", target = "Angiografør/Operatør")
     }
-    if (shiny::req(user$role()) == "SC") {
-      shiny::showTab(inputId = "tabs", target = "Utforsker")
-      shiny::showTab(inputId = "tabs", target = "Datadump")
-      shiny::showTab(inputId = "tabs", target = "Verktøy")
-      shiny::showTab(inputId = "tabs", target = "Angiografør/Operatør")
-      shiny::showTab(inputId = "tabs", target = "Kodebok")
-      shiny::showTab(inputId = "tabs", target = "Nedlasting rapporter")
-    }
-  })
 
-  ## local reports/tabs for national registry
-  shiny::observeEvent(user$org(), {
     if (isNationalReg(shiny::req(user$org()))) {
       shiny::hideTab(inputId = "tabs", target = "Prosedyrer")
       shiny::hideTab(inputId = "tabs", target = "Angiografør/Operatør")
       shiny::hideTab(inputId = "tabs", target = "Månedsrapporter")
       shiny::hideTab(inputId = "tabs", target = "Abonnement")
-      shiny::showTab(inputId = "tabs", target = "Utsending")
-      shiny::showTab(inputId = "tabs", target = "Bruksstatistikk")
-      shiny::showTab(inputId = "tabs", target = "Nedlasting rapporter")
     }
   
     ## dispatchment and use stats hidden when not national registry
     if (!isNationalReg(shiny::req(user$org()))) {
-      shiny::showTab(inputId = "tabs", target = "Prosedyrer")
-      shiny::showTab(inputId = "tabs", target = "Angiografør/Operatør")
-      shiny::showTab(inputId = "tabs", target = "Månedsrapporter")
-      shiny::showTab(inputId = "tabs", target = "Abonnement")
       shiny::hideTab(inputId = "tabs", target = "Utsending")
       shiny::hideTab(inputId = "tabs", target = "Bruksstatistikk")
       shiny::hideTab(inputId = "tabs", target = "Nedlasting rapporter")


### PR DESCRIPTION
Vis alle faner ved start og skjul hvis rolle tilsier det. Dette er sårbart siden brukere med rolle som ikke er LU eller LC vil få se alt