### PR TITLE
Send miljøvariablen GH_PAT til docker-bygging

### DIFF
--- a/.github/workflows/harbor.yaml
+++ b/.github/workflows/harbor.yaml
@@ -56,3 +56,4 @@ jobs:
           push: ${{ github.event_name == 'release' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: GH_PAT=${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Bygging av docker image kan krasje på grunn av 'GitHub API rate limit' hvis image ikke har tilgang på Github Personal Access Token. PAT må sendes inn som argument under bygging.
