### PR TITLE
Knapp i QA for utsending av rapporter

### DIFF
--- a/inst/shinyApps/noric/server.R
+++ b/inst/shinyApps/noric/server.R
@@ -737,8 +737,7 @@ shinyServer(function(input, output, session) {
                             paramValues = subParamValues,
                             reports = subReports, 
                             orgs = orgs,
-                            user = user,
-                            runAutoReportButton = (Sys.getenv("R_RAP_INSTANCE") %in% c("QAC", "DEV", "TEST")))
+                            user = user)
   
   
   # Ny Utsending 


### PR DESCRIPTION
I QA (ikke i prod) vil det dukke opp en knapp der man kan tvinge frem bygging av rapporter (og utsendinger av e-post, hvis man vil) i utsendings-fanen. Man slipper da å vente til neste dag med å sjekke at rapportutsending fungerer.

Det vi se slik ut (markert i rødt):
<img width="830" height="1002" alt="image" src="https://github.com/user-attachments/assets/8daabaab-c6db-425d-b4de-355b45ea6e2f" />
