### PR TITLE
Klargjør app for ny versjon av rapbase

### DIFF
--- a/inst/shinyApps/noric/server.R
+++ b/inst/shinyApps/noric/server.R
@@ -856,12 +856,12 @@ shinyServer(function(input, output, session) {
                             registryName = "noric")
 
   # Verktøy - Eksport
-  rapbase::exportUCServer(id = "noricExport",
-                          registryName = registryName,
-                          repoName = "noric")
+  rapbase::exportUCServer("noricExport",
+                          registryName,
+                          "noric")
 
-  rapbase::exportGuideServer(id = "noricExportGuide",
-                             registryName = registryName)
+  rapbase::exportGuideServer("noricExportGuide",
+                             registryName)
   
   
   # Verktøy - Staging data


### PR DESCRIPTION
exportUCServer og exportGuideServer skal få nye navn på variabler, som samsvarer med hva de er. Dropper derfor eksplisitt variabelnavn i kall. Se https://github.com/Rapporteket/rapbase/pull/347