### PR TITLE
Github-installasjon av pakken rpivottable

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,7 +48,8 @@ Imports:
   yaml
 Remotes:
   Rapporteket/rapbase@main,
-  andrewsali/shinycssloaders
+  andrewsali/shinycssloaders,
+  smartinsightsfromdata/rpivotTable
 RoxygenNote: 7.3.2
 Suggests: 
     covr, 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,6 +39,7 @@ Imports:
   revealjs,
   rlang,
   rmarkdown,
+  rpivotTable,
   shiny,
   shinyalert,
   shinycssloaders,
@@ -53,5 +54,4 @@ Remotes:
 RoxygenNote: 7.3.2
 Suggests: 
     covr, 
-    rpivotTable,
     testthat

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,6 @@ Imports:
   revealjs,
   rlang,
   rmarkdown,
-  rpivotTable,
   shiny,
   shinyalert,
   shinycssloaders,
@@ -53,4 +52,5 @@ Remotes:
 RoxygenNote: 7.3.2
 Suggests: 
     covr, 
+    rpivotTable,
     testthat


### PR DESCRIPTION
Finnes ikke lenger på cran, så må bygge fra versjonen som ligger på github.
