### PR TITLE
Docker: mat inn secrets/repo + diverse

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,5 +1,3 @@
-# For help debugging build failures open an issue on the RStudio community with the 'github-actions' tag.
-# https://community.rstudio.com/new-topic?category=Package%20development&tags=github-actions
 on:
   push:
     branches:
@@ -27,14 +25,12 @@ jobs:
       matrix:
         config:
           - {os: windows-latest, r: 'release'}
-          - {os: macOS-latest, r: 'release'}
           - {os: ubuntu-24.04, r: 'release'}
-          - {os: ubuntu-24.04, r: 'devel'}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      RSPM: ${{ matrix.config.rspm }}
-      GITHUB_PAT: ${{ secrets.GH_TOKEN }}
+      R_COMPILE_AND_INSTALL_PACKAGES: never
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - uses: actions/checkout@v4
@@ -42,6 +38,7 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
+          use-public-rspm: true
 
       - uses: r-lib/actions/setup-pandoc@v2
       
@@ -69,17 +66,7 @@ jobs:
           extra-packages: any::rcmdcheck
           needs: check
 
-      - name: Check
-        env:
-          _R_CHECK_CRAN_INCOMING_REMOTE_: false
-        run: |
-          options(crayon.enabled = TRUE)
-          rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "error", check_dir = "check")
-        shell: Rscript {0}
-
-      - name: Upload check results
-        if: failure()
-        uses: actions/upload-artifact@v4
+      - uses: r-lib/actions/check-r-package@v2
         with:
-          name: ${{ runner.os }}-r${{ matrix.config.r }}-results
-          path: check
+          error-on: '"error"'
+          args: c("--no-manual") # Avoid "--as-cran"

--- a/.github/workflows/harbor.yaml
+++ b/.github/workflows/harbor.yaml
@@ -18,21 +18,17 @@ jobs:
     name: Push Docker image to Harbor
     runs-on: ubuntu-latest
     env:
-        IMAGE_NAME: ${{ github.repository }}
+      IMAGE_NAME: ${{ github.repository }}
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Lint Dockerfile
-        uses: hadolint/hadolint-action@v3.1.0
+        uses: hadolint/hadolint-action@v3.3.0
         with:
           dockerfile: "Dockerfile"
-      - name: R setup
-        uses: r-lib/actions/setup-r@v2
-      - name: Build package (tarball)
-        run: R CMD build .
       - name: Prepare tags
         id: docker_meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.IMAGE_NAME }}
           flavor: |
@@ -42,18 +38,20 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Login to Harbor
         if: github.event_name == 'release'
         run: |
           echo ${{ secrets.HARBOR_PASSWORD }} | docker login --username ${{ secrets.HARBOR_USERNAME }} --password-stdin ${{ secrets.HARBOR_REGISTRY }}
       - name: Build image and push to Harbor
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
           tags: ${{ secrets.HARBOR_REGISTRY }}/${{ steps.docker_meta.outputs.tags }}
           push: ${{ github.event_name == 'release' }}
+          pull: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          build-args: GH_PAT=${{ secrets.GITHUB_TOKEN }}
+          secrets: |
+            "github_pat=${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,11 +2,9 @@ on:
   push:
     branches:
       - main
-      - master
   pull_request:
     branches:
       - main
-      - master
 
 name: lint
 
@@ -19,10 +17,13 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_COMPILE_AND_INSTALL_PACKAGES: never
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -23,12 +23,15 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_COMPILE_AND_INSTALL_PACKAGES: never
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -18,7 +18,8 @@ jobs:
   test-coverage:
     runs-on: ubuntu-24.04
     env:
-      GITHUB_PAT: ${{ secrets.GH_TOKEN }}
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_COMPILE_AND_INSTALL_PACKAGES: never
       GITHUB_ACTIONS_RUN_DB_UNIT_TESTS: true
       MYSQL_HOST: "localhost"
       MYSQL_USER: "root"
@@ -27,6 +28,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
 
       - uses: r-lib/actions/setup-pandoc@v2
       

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,10 @@
 FROM rapporteket/base-r:main
 
-LABEL maintainer="Arnfinn Hykkerud Steindal <arnfinn.hykkerud.steindal@helse-nord.no>"
-LABEL no.rapporteket.cd.enable="true"
-
-ARG GH_PAT
-ENV GITHUB_PAT=${GH_PAT}
-
 WORKDIR /app/R
 
-COPY *.tar.gz .
-
-RUN R -e "remotes::install_local(list.files(pattern = \"*.tar.gz\"))" \
-  && rm ./*.tar.gz \
+RUN --mount=type=secret,id=github_pat,env=GITHUB_PAT \
+    --mount=type=bind,source=.,target=/app/R/pkg \
+    R -e "remotes::install_local(path = './pkg')" \
   && R -e "remotes::install_github(\"Rapporteket/rapbase\", ref = \"main\")"
 
 EXPOSE 3838
@@ -21,4 +14,4 @@ RUN adduser --uid "1000" --disabled-password rapporteket && \
     chmod -R 755 /app/R
 USER rapporteket
 
-CMD ["R", "-e", "options(shiny.port = 3838, shiny.host = \"0.0.0.0\"); shiny::runApp(system.file('shinyApps/noric', package = 'noric'))"]
+CMD ["R", "-e", "options(shiny.port = 3838, shiny.host = \"0.0.0.0\"); ablanor::run_app()"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ RUN adduser --uid "1000" --disabled-password rapporteket && \
     chmod -R 755 /app/R
 USER rapporteket
 
-CMD ["R", "-e", "options(shiny.port = 3838, shiny.host = \"0.0.0.0\"); ablanor::run_app()"]
+CMD ["R", "-e", "options(shiny.port = 3838, shiny.host = \"0.0.0.0\"); shiny::runApp(system.file('shinyApps/noric', package = 'noric'))"]


### PR DESCRIPTION
- Matet inn secrets, slik at de ikke være synlig i bygg etterpå.
- Matet inn repo og bygde pakken inne i Dockerfile. Det betyr at det ikke lenger er nødvendig å bygge en tar.gz-fil utenfor før man bygger image. Da slipper man å sette opp R-miljø i action.
- Byttet i tillegg til GITHUB_TOKEN, som kun finnes midlertidig mens jobb kjører.
- Oppdatert også actions-jobber med diverse små-endringer. 
- Prøvd å gjøre jobbene kjappere ved å bruke ferdig-installerte pakker.